### PR TITLE
Fix default value for max NAL unit size for H.265

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Fixed
+
+ - Fix the `SmolRTSP_NalTransportConfig_default` value for H.265 ([PR #17](https://github.com/OpenIPC/smolrtsp/pull/17)).
+
 ## 0.1.3 - 2023-03-12
 
 ### Fixed

--- a/src/nal_transport.c
+++ b/src/nal_transport.c
@@ -18,7 +18,7 @@ static int send_fu(
 SmolRTSP_NalTransportConfig SmolRTSP_NalTransportConfig_default(void) {
     return (SmolRTSP_NalTransportConfig){
         .max_h264_nalu_size = SMOLRTSP_MAX_H264_NALU_SIZE,
-        .max_h265_nalu_size = SMOLRTSP_MAX_H264_NALU_SIZE,
+        .max_h265_nalu_size = SMOLRTSP_MAX_H265_NALU_SIZE,
     };
 }
 


### PR DESCRIPTION
I'm not sure if this is actually an issue, but this fixes `SmolRTSP_NalTransportConfig_default()` to initialise `.max_h265_nalu_size` to `SMOLRTSP_MAX_H265_NALU_SIZE` rather than the H.264 size.