### PR TITLE
change precompile_headers to private to support build in cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ endif()
 
 # Precompile headers that use Datatype99/Interface99.
 target_precompile_headers(
-  ${PROJECT_NAME} PUBLIC
+  ${PROJECT_NAME} PRIVATE
   include/smolrtsp/types/error.h
   include/smolrtsp/nal/h264.h
   include/smolrtsp/nal/h265.h


### PR DESCRIPTION
How about chaning precompile_headers to private？

otherwise it would failed when using this lib in cpp project:(as the c99 grammers used in interface99 are not support by cpp, like restrict..etc)

```
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h: In function ‘Slice99 Slice99_empty(size_t)’:
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h:537:24: error: invalid conversion from ‘const void*’ to ‘void*’ [-fpermissive]
  537 |     return Slice99_new("", item_size, 0);
      |                        ^~
      |                        |
      |                        const void*
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h:483:19: note:   initializing argument 1 of ‘Slice99 Slice99_new(void*, size_t, size_t)’
  483 | Slice99_new(void *ptr, size_t item_size, size_t len) {
      |             ~~~~~~^~~
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h: At global scope:
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h:802:92: error: expected ‘,’ or ‘...’ before ‘backup’
  802 | inline static void Slice99_swap(Slice99 self, ptrdiff_t lhs, ptrdiff_t rhs, void *restrict backup) {
      |                                                                                            ^~~~~~
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h: In function ‘void Slice99_swap(Slice99, ptrdiff_t, ptrdiff_t, void*)’:
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h:803:5: error: ‘backup’ was not declared in this scope
  803 |     SLICE99_ASSERT(backup);
      |     ^~~~~~~~~~~~~~
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h: At global scope:
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h:823:88: error: expected ‘,’ or ‘...’ before ‘backup’
  823 | inline static void Slice99_swap_with_slice(Slice99 self, Slice99 other, void *restrict backup) {
      |                                                                                        ^~~~~~
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h: In function ‘void Slice99_swap_with_slice(Slice99, Slice99, void*)’:
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h:828:24: error: ‘backup’ was not declared in this scope
  828 |         SLICE99_MEMCPY(backup, Slice99_get(self, i), self.item_size);
      |                        ^~~~~~
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h: At global scope:
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h:843:65: error: expected ‘,’ or ‘...’ before ‘backup’
  843 | inline static void Slice99_reverse(Slice99 self, void *restrict backup) {
      |                                                                 ^~~~~~
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h: In function ‘void Slice99_reverse(Slice99, void*)’:
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h:844:5: error: ‘backup’ was not declared in this scope
  844 |     SLICE99_ASSERT(backup);
      |     ^~~~~~~~~~~~~~
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h: At global scope:
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h:865:60: error: expected ‘,’ or ‘...’ before ‘lhs’
  865 | Slice99_split_at(Slice99 self, size_t i, Slice99 *restrict lhs, Slice99 *restrict rhs) {
      |                                                            ^~~
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h: In function ‘void Slice99_split_at(Slice99, size_t, Slice99*)’:
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h:867:5: error: ‘lhs’ was not declared in this scope
  867 |     SLICE99_ASSERT(lhs);
      |     ^~~~~~~~~~~~~~
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h:868:5: error: ‘rhs’ was not declared in this scope
  868 |     SLICE99_ASSERT(rhs);
      |     ^~~~~~~~~~~~~~
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h: At global scope:
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h:885:58: error: ‘restrict’ was not declared in this scope; did you mean ‘struct’?
  885 | inline static char *Slice99_c_str(Slice99 self, char out[restrict]) {
      |                                                          ^~~~~~~~
      |                                                          struct
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h: In function ‘char* Slice99_c_str(...)’:
/home/radxa/rockchip_camera/build/_deps/slice99-src/slice99.h:886:5: error: ‘out’ was not declared in this scope
  886 |     SLICE99_ASSERT(out);
      |     ^~~~~~~~~~~~~~
```

and make the pre_compile headers to private could solve this problem.

