### PR TITLE
Add RTCP Sender Report (SR) serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Added
+
+ - RTCP Sender Report (SR) serialization per [RFC 3550 §6.4.1](https://datatracker.ietf.org/doc/html/rfc3550#section-6.4.1). New header `smolrtsp/types/rtcp.h` exposing `SmolRTSP_RtcpSr`, `SmolRTSP_RtcpSr_size`, and `SmolRTSP_RtcpSr_serialize`. Currently emits the fixed 28-byte SR header (RC = 0); reception report blocks, SDES and BYE remain unimplemented (see #7).
+
 ### Fixed
 
  - Update the minimum required CMake version to 3.10.0 due to deprecation (see [metalang99/issues/33](https://github.com/hirrolot/metalang99/issues/33)).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ set(SMOLRTSP_SOURCES
     include/smolrtsp/types/status_code.h
     include/smolrtsp/types/sdp.h
     include/smolrtsp/types/rtp.h
+    include/smolrtsp/types/rtcp.h
     include/smolrtsp/nal/h264.h
     include/smolrtsp/nal/h265.h
     include/smolrtsp/nal.h
@@ -79,6 +80,7 @@ set(SMOLRTSP_SOURCES
     src/types/status_code.c
     src/types/sdp.c
     src/types/rtp.c
+    src/types/rtcp.c
     src/nal/h264.c
     src/nal/h265.c
     src/nal.c

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ SmolRTSP is a simple [RTSP 1.0] server library tailored for embedded devices, su
    - [x] RTP over TCP (interleaved binary data)
    - [x] RTP over UDP
    - [x] SDP ([RFC 4566])
-   - [ ] RTCP
+   - RTCP ([RFC 3550]):
+     - [x] Sender Report (SR) serialization
+     - [ ] Receiver Report (RR), SDES, BYE
  - Supported RTP payload formats:
    - [x] H.264 ([RFC 6184])
    - [x] H.265 ([RFC 7798])

--- a/include/smolrtsp/types/rtcp.h
+++ b/include/smolrtsp/types/rtcp.h
@@ -1,0 +1,133 @@
+/**
+ * @file
+ * @brief <a
+ * href="https://datatracker.ietf.org/doc/html/rfc3550#section-6.4">RFC 3550
+ * §6.4</a>-compliant RTCP Sender Report (SR) implementation.
+ */
+
+#pragma once
+
+#include <smolrtsp/priv/compiler_attrs.h>
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * RTCP packet type for Sender Report (RFC 3550 §6.4.1).
+ */
+#define SMOLRTSP_RTCP_PT_SR 200
+
+/**
+ * The fixed wire size of an RTCP Sender Report with no reception report
+ * blocks (RC = 0).
+ *
+ * 4 (common header) + 4 (sender SSRC) + 8 (NTP timestamp) + 4 (RTP timestamp)
+ * + 4 (packet count) + 4 (octet count) = 28 bytes.
+ */
+#define SMOLRTSP_RTCP_SR_SIZE_BASE 28u
+
+/**
+ * An RTCP Sender Report (SR) header.
+ *
+ *  0                   1                   2                   3
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |V=2|P|    RC   |   PT=SR=200   |             length            |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                         SSRC of sender                        |
+ * +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+ * |              NTP timestamp, most significant word             |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |             NTP timestamp, least significant word             |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                         RTP timestamp                         |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                     sender's packet count                     |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                      sender's octet count                     |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *
+ * All multi-byte numerical fields must be in network byte order, with the
+ * exception of #ssrc which is treated as opaque (sender and receiver compare
+ * it as a bit pattern, so either endianness is acceptable provided it stays
+ * consistent with the matching RTP stream).
+ *
+ * Reception report blocks (RC > 0) and chained SDES/BYE packets are not yet
+ * supported by this serializer; #rc must be zero.
+ */
+typedef struct {
+    /**
+     * (1 bit) Padding flag. When set, the SR ends with extra padding octets
+     * whose count is given in the last byte. Typically `false`.
+     */
+    bool padding;
+
+    /**
+     * (5 bits) Reception report count. Must be `0` for this implementation.
+     */
+    uint8_t rc;
+
+    /**
+     * (32 bits) Synchronization source identifier of the sender. Must match
+     * the SSRC of the corresponding RTP stream. Treated as opaque on the
+     * wire.
+     */
+    uint32_t ssrc;
+
+    /**
+     * (32 bits) NTP-epoch seconds. NTP epoch is 1900-01-01 UTC; converting
+     * a Unix-epoch value requires adding 2208988800. Network byte order.
+     */
+    uint32_t ntp_sec;
+
+    /**
+     * (32 bits) NTP fractional seconds. 2^32 represents one full second.
+     * Network byte order.
+     */
+    uint32_t ntp_frac;
+
+    /**
+     * (32 bits) The RTP timestamp that corresponds to the same instant as
+     * the NTP timestamp above. Receivers use this pair to map any RTP
+     * timestamp to wall-clock time. Network byte order.
+     */
+    uint32_t rtp_ts;
+
+    /**
+     * (32 bits) Total number of RTP data packets transmitted by the sender
+     * since starting transmission, up to the time this SR was generated.
+     * Network byte order.
+     */
+    uint32_t pkt_count;
+
+    /**
+     * (32 bits) Total number of payload octets (i.e., not including header
+     * or padding) transmitted by the sender since starting transmission.
+     * Network byte order.
+     */
+    uint32_t octet_count;
+} SmolRTSP_RtcpSr;
+
+/**
+ * Computes the size of the binary @p self.
+ *
+ * Currently always returns #SMOLRTSP_RTCP_SR_SIZE_BASE; reserved for future
+ * support of reception report blocks.
+ */
+size_t SmolRTSP_RtcpSr_size(SmolRTSP_RtcpSr self) SMOLRTSP_PRIV_MUST_USE;
+
+/**
+ * Writes @p self to @p buffer.
+ *
+ * @param[in] self The SR packet to write.
+ * @param[out] buffer The pointer to write to. Must be at least of size
+ * `SmolRTSP_RtcpSr_size(self)`.
+ *
+ * @return The pointer to the passed buffer.
+ *
+ * @pre `buffer != NULL`
+ * @pre `self.rc == 0` (reception report blocks not yet supported)
+ */
+uint8_t *SmolRTSP_RtcpSr_serialize(
+    SmolRTSP_RtcpSr self, uint8_t buffer[restrict]) SMOLRTSP_PRIV_MUST_USE;

--- a/src/types/rtcp.c
+++ b/src/types/rtcp.c
@@ -1,0 +1,60 @@
+#include <smolrtsp/types/rtcp.h>
+
+#include <assert.h>
+#include <string.h>
+
+#include <arpa/inet.h>
+
+#include <slice99.h>
+
+#define RTCP_HEADER_VERSION_SHIFT 6
+#define RTCP_HEADER_PADDING_SHIFT 5
+#define RTCP_VERSION              2
+
+size_t SmolRTSP_RtcpSr_size(SmolRTSP_RtcpSr self) {
+    (void)self;
+    return SMOLRTSP_RTCP_SR_SIZE_BASE;
+}
+
+uint8_t *
+SmolRTSP_RtcpSr_serialize(SmolRTSP_RtcpSr self, uint8_t buffer[restrict]) {
+    assert(buffer);
+    assert(self.rc == 0 && "RTCP SR reception report blocks not yet supported");
+
+    uint8_t *buffer_backup = buffer;
+
+    /*
+     *  0                   1                   2                   3
+     *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     * |V=2|P|    RC   |   PT=SR=200   |             length            |
+     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     */
+
+    /* Pack V (2 bits), P (1 bit), RC (5 bits) into byte 0. */
+    *buffer =
+        ((uint8_t)RTCP_VERSION << RTCP_HEADER_VERSION_SHIFT) | (self.rc & 0x1f);
+    if (self.padding) {
+        *buffer |= ((uint8_t)1 << RTCP_HEADER_PADDING_SHIFT);
+    }
+    buffer++;
+
+    /* PT (8 bits). */
+    *buffer = (uint8_t)SMOLRTSP_RTCP_PT_SR;
+    buffer++;
+
+    /* Length: in 32-bit words minus one. For a base SR (28 B = 7 words),
+     * length = 6. Network byte order. */
+    const uint16_t length_be =
+        htons((uint16_t)((SMOLRTSP_RTCP_SR_SIZE_BASE / 4u) - 1u));
+    buffer = SLICE99_APPEND(buffer, length_be);
+
+    buffer = SLICE99_APPEND(buffer, self.ssrc);
+    buffer = SLICE99_APPEND(buffer, self.ntp_sec);
+    buffer = SLICE99_APPEND(buffer, self.ntp_frac);
+    buffer = SLICE99_APPEND(buffer, self.rtp_ts);
+    buffer = SLICE99_APPEND(buffer, self.pkt_count);
+    buffer = SLICE99_APPEND(buffer, self.octet_count);
+
+    return buffer_backup;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(
   types/rtsp_version.c
   types/status_code.c
   types/sdp.c
+  types/rtcp.c
   types/test_util.h
   nal/h264.c
   nal/h265.c

--- a/tests/main.c
+++ b/tests/main.c
@@ -25,6 +25,7 @@ int main(int argc, char *argv[]) {
     SMOLRTSP_SUITE(types_rtsp_version);
     SMOLRTSP_SUITE(types_sdp);
     SMOLRTSP_SUITE(types_status_code);
+    SMOLRTSP_SUITE(types_rtcp);
 
     SMOLRTSP_SUITE(nal_h264);
     SMOLRTSP_SUITE(nal_h265);

--- a/tests/types/rtcp.c
+++ b/tests/types/rtcp.c
@@ -1,0 +1,108 @@
+#include <smolrtsp/types/rtcp.h>
+
+#include <arpa/inet.h>
+#include <string.h>
+
+#include <greatest.h>
+
+TEST sr_size_is_28_for_no_report_blocks(void) {
+    const SmolRTSP_RtcpSr sr = {0};
+    ASSERT_EQ((size_t)28, SmolRTSP_RtcpSr_size(sr));
+    ASSERT_EQ((size_t)SMOLRTSP_RTCP_SR_SIZE_BASE, SmolRTSP_RtcpSr_size(sr));
+    PASS();
+}
+
+TEST sr_serialize_wire_format(void) {
+    /*
+     * Build an SR with known field values, then check every byte against the
+     * RFC 3550 §6.4.1 wire format.
+     */
+    const SmolRTSP_RtcpSr sr = {
+        .padding = false,
+        .rc = 0,
+        .ssrc = htonl(0xdeadbeef),
+        .ntp_sec = htonl(0xe79c69b4u),  /* example NTP seconds */
+        .ntp_frac = htonl(0x80000000u), /* exactly 0.5 s */
+        .rtp_ts = htonl(0x12345678u),
+        .pkt_count = htonl(42),
+        .octet_count = htonl(1234567),
+    };
+
+    uint8_t buf[64] = {0};
+    const uint8_t *ret = SmolRTSP_RtcpSr_serialize(sr, buf);
+    ASSERT_EQ((const uint8_t *)buf, ret);
+
+    /* Common header byte 0: V=2 (10), P=0, RC=0 → 0b10000000 = 0x80. */
+    ASSERT_EQ_FMT((uint8_t)0x80, buf[0], "0x%02x");
+
+    /* Payload type byte 1: SR = 200 (0xc8). */
+    ASSERT_EQ_FMT((uint8_t)200, buf[1], "%u");
+    ASSERT_EQ_FMT((uint8_t)SMOLRTSP_RTCP_PT_SR, buf[1], "%u");
+
+    /* Length bytes 2-3: 28 B / 4 - 1 = 6 → 0x0006 in network order. */
+    ASSERT_EQ_FMT((uint8_t)0x00, buf[2], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0x06, buf[3], "0x%02x");
+
+    /* SSRC bytes 4-7: 0xdeadbeef in network order. */
+    ASSERT_EQ_FMT((uint8_t)0xde, buf[4], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0xad, buf[5], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0xbe, buf[6], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0xef, buf[7], "0x%02x");
+
+    /* NTP seconds 8-11. */
+    ASSERT_EQ_FMT((uint8_t)0xe7, buf[8], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0x9c, buf[9], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0x69, buf[10], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0xb4, buf[11], "0x%02x");
+
+    /* NTP fraction 12-15: 0x80000000 = 0.5 s. */
+    ASSERT_EQ_FMT((uint8_t)0x80, buf[12], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0x00, buf[13], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0x00, buf[14], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0x00, buf[15], "0x%02x");
+
+    /* RTP timestamp 16-19. */
+    ASSERT_EQ_FMT((uint8_t)0x12, buf[16], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0x34, buf[17], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0x56, buf[18], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0x78, buf[19], "0x%02x");
+
+    /* Packet count 20-23: 42 = 0x0000002a. */
+    ASSERT_EQ_FMT((uint8_t)0x00, buf[20], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0x00, buf[21], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0x00, buf[22], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0x2a, buf[23], "0x%02x");
+
+    /* Octet count 24-27: 1234567 = 0x0012d687. */
+    ASSERT_EQ_FMT((uint8_t)0x00, buf[24], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0x12, buf[25], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0xd6, buf[26], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0x87, buf[27], "0x%02x");
+
+    /* Trailing bytes untouched. */
+    for (size_t i = SMOLRTSP_RTCP_SR_SIZE_BASE; i < sizeof(buf); i++) {
+        ASSERT_EQ_FMT((uint8_t)0, buf[i], "0x%02x");
+    }
+
+    PASS();
+}
+
+TEST sr_serialize_padding_flag(void) {
+    SmolRTSP_RtcpSr sr = {0};
+    sr.padding = true;
+
+    uint8_t buf[SMOLRTSP_RTCP_SR_SIZE_BASE] = {0};
+    const uint8_t *ret = SmolRTSP_RtcpSr_serialize(sr, buf);
+    ASSERT_EQ((const uint8_t *)buf, ret);
+
+    /* V=2, P=1, RC=0 → 0b10100000 = 0xa0. */
+    ASSERT_EQ_FMT((uint8_t)0xa0, buf[0], "0x%02x");
+
+    PASS();
+}
+
+SUITE(types_rtcp) {
+    RUN_TEST(sr_size_is_28_for_no_report_blocks);
+    RUN_TEST(sr_serialize_wire_format);
+    RUN_TEST(sr_serialize_padding_flag);
+}


### PR DESCRIPTION
Closes OpenIPC/majestic#29.

Adds a minimal SR serializer per [RFC 3550 §6.4.1](https://datatracker.ietf.org/doc/html/rfc3550#section-6.4.1) so RTSP/RTP streams can carry an NTP-anchored wall-clock timestamp alongside their RTP timestamps. Receivers (e.g. `gst-rtspsrc ntp-sync=true`) can then recover true frame capture time from the (NTP, RTP) pair. Reception report blocks (RC > 0), SDES, and BYE are explicitly out of scope.

## What's new

- **`include/smolrtsp/types/rtcp.h`** — `SmolRTSP_RtcpSr`, `SMOLRTSP_RTCP_PT_SR`, `SMOLRTSP_RTCP_SR_SIZE_BASE`, plus `SmolRTSP_RtcpSr_size` / `SmolRTSP_RtcpSr_serialize`. Byte-order convention follows the existing `SmolRTSP_RtpHeader` — caller pre-converts multi-byte fields to network byte order, library memcpy's bytes.
- **`src/types/rtcp.c`** — packs the 28-byte fixed SR (V=2, P, RC, PT=200, length=6 words, SSRC, NTP timestamp, RTP timestamp, sender packet count, sender octet count).
- **`tests/types/rtcp.c`** — three tests under the new `types_rtcp` suite. Coverage: `_size()` equals 28, byte-by-byte verification of `_serialize()` against the RFC wire format with known values, and the padding-flag bit packing.

## Why this matters

`SmolRTSP_RtpTransport` currently sends RTP timestamps derived from either a raw 32-bit value or a `clock_gettime`-style microsecond stream. Neither is anchored to wall-clock at the receiver — that's exactly what the RTCP SR NTP-timestamp field provides. Without SR, downstream consumers can't correlate RTP timestamps to true capture time, which limits:

- robotics / multi-sensor fusion (camera-frame stamps vs IMU vs LIDAR)
- forensic / evidence-chain workflows
- AWS Kinesis-style ingestion that depends on RTCP for media sync (cf. OpenIPC/firmware#1480 / OpenIPC/firmware#1479)
- the downstream RFC 2326 SETUP-response compliance gap tracked in OpenIPC/majestic#52 and at OpenIPC/majestic#222 — once SR construction exists, returning `server_port=...-...` in SETUP becomes meaningful

A related upstream kernel-side capture proposal at [OpenIPC/openhisilicon#144](https://github.com/OpenIPC/openhisilicon/issues/144) (sensor frame-start IRQ → wall-clock chrdev) gives sub-frame-accurate `(pts, wall_ns)` pairs that would naturally feed the NTP-timestamp field added here.

## What this PR doesn't do

This is intentionally just the serializer. Out of scope:

- **RTCP socket binding / periodic SR emission** in `SmolRTSP_RtpTransport` — best done in the libevent integration since that's where timers already live.
- **Reception Reports (RC > 0), SDES, BYE.** `_serialize` asserts on `rc == 0`.
- **Receiver-side parsing of SR.** The library is server-focused; receiver-side parsing belongs in a follow-up if/when needed.

Happy to follow up with the periodic-emit wiring in `smolrtsp-libevent` once this lands, if you agree on the direction.

## Testing

```
cd tests && cmake -B build -G Ninja && cmake --build build && ./build/tests
...
* Suite types_rtcp:
...
Total: 74 tests (4633 ticks, 0.005 sec), 983 assertions
Pass: 74, fail: 0, skip: 0.
```

Pre-PR suite was 71 tests / 980 assertions; this PR adds three tests and three assertions. Code passes `clang-format` against the project's `.clang-format`. AddressSanitizer build (the tests/ default) is clean.