### PR TITLE
Expose SSRC + packet/octet counters on SmolRTSP_RtpTransport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
  - RTCP Sender Report (SR) serialization per [RFC 3550 §6.4.1](https://datatracker.ietf.org/doc/html/rfc3550#section-6.4.1). New header `smolrtsp/types/rtcp.h` exposing `SmolRTSP_RtcpSr`, `SmolRTSP_RtcpSr_size`, and `SmolRTSP_RtcpSr_serialize`. Currently emits the fixed 28-byte SR header (RC = 0); reception report blocks, SDES and BYE remain unimplemented (see #7).
+ - `SmolRTSP_RtpTransport_ssrc`, `SmolRTSP_RtpTransport_pkt_count`, and `SmolRTSP_RtpTransport_octet_count` accessors so callers can populate the corresponding fields of an RTCP Sender Report. `pkt_count` and `octet_count` are now tracked inside `SmolRTSP_RtpTransport` and advance with each successful `_send_packet` call.
 
 ### Fixed
 

--- a/include/smolrtsp/rtp_transport.h
+++ b/include/smolrtsp/rtp_transport.h
@@ -85,3 +85,42 @@ int SmolRTSP_RtpTransport_send_packet(
 declImplExtern99(SmolRTSP_Droppable, SmolRTSP_RtpTransport);
 
 bool SmolRTSP_RtpTransport_is_full(SmolRTSP_RtpTransport *self);
+
+/**
+ * Returns the Synchronization Source (SSRC) identifier used by @p self
+ * on every RTP packet it sends.
+ *
+ * Useful when constructing an RTCP Sender Report (see
+ * #SmolRTSP_RtcpSr in `<smolrtsp/types/rtcp.h>`) that needs to carry
+ * the matching SSRC so receivers can pair the SR with the RTP stream
+ * per RFC 3550 §6.4.1.
+ *
+ * @pre `self != NULL`
+ */
+uint32_t
+SmolRTSP_RtpTransport_ssrc(SmolRTSP_RtpTransport *self) SMOLRTSP_PRIV_MUST_USE;
+
+/**
+ * Returns the total number of RTP data packets successfully transmitted
+ * by @p self since it was created.
+ *
+ * Maps to the "sender's packet count" field of an RTCP Sender Report
+ * (RFC 3550 §6.4.1).
+ *
+ * @pre `self != NULL`
+ */
+uint32_t SmolRTSP_RtpTransport_pkt_count(SmolRTSP_RtpTransport *self)
+    SMOLRTSP_PRIV_MUST_USE;
+
+/**
+ * Returns the total number of payload octets (i.e., not including the
+ * RTP header or padding) successfully transmitted by @p self since it
+ * was created.
+ *
+ * Maps to the "sender's octet count" field of an RTCP Sender Report
+ * (RFC 3550 §6.4.1).
+ *
+ * @pre `self != NULL`
+ */
+uint32_t SmolRTSP_RtpTransport_octet_count(SmolRTSP_RtpTransport *self)
+    SMOLRTSP_PRIV_MUST_USE;

--- a/src/rtp_transport.c
+++ b/src/rtp_transport.c
@@ -11,6 +11,8 @@
 struct SmolRTSP_RtpTransport {
     uint16_t seq_num;
     uint32_t ssrc;
+    uint32_t pkt_count;
+    uint32_t octet_count;
     uint8_t payload_ty;
     uint32_t clock_rate;
     SmolRTSP_Transport transport;
@@ -28,6 +30,8 @@ SmolRTSP_RtpTransport *SmolRTSP_RtpTransport_new(
 
     self->seq_num = 0;
     self->ssrc = (uint32_t)rand();
+    self->pkt_count = 0;
+    self->octet_count = 0;
     self->payload_ty = payload_ty;
     self->clock_rate = clock_rate;
     self->transport = t;
@@ -82,6 +86,11 @@ int SmolRTSP_RtpTransport_send_packet(
     const int ret = VCALL(self->transport, transmit, bufs);
     if (ret != -1) {
         self->seq_num++;
+        self->pkt_count++;
+        /* RFC 3550 §6.4.1: octet count covers payload only (no RTP header
+         * or padding). The codec-specific `payload_header` is part of the
+         * payload from the receiver's point of view. */
+        self->octet_count += (uint32_t)(payload_header.len + payload.len);
     }
 
     return ret;
@@ -107,4 +116,19 @@ compute_timestamp(SmolRTSP_RtpTimestamp ts, uint32_t clock_rate) {
 
 bool SmolRTSP_RtpTransport_is_full(SmolRTSP_RtpTransport *self) {
     return VCALL(self->transport, is_full);
+}
+
+uint32_t SmolRTSP_RtpTransport_ssrc(SmolRTSP_RtpTransport *self) {
+    assert(self);
+    return self->ssrc;
+}
+
+uint32_t SmolRTSP_RtpTransport_pkt_count(SmolRTSP_RtpTransport *self) {
+    assert(self);
+    return self->pkt_count;
+}
+
+uint32_t SmolRTSP_RtpTransport_octet_count(SmolRTSP_RtpTransport *self) {
+    assert(self);
+    return self->octet_count;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,7 +43,8 @@ add_executable(
   io_vec.c
   controller.c
   context.c
-  transport.c)
+  transport.c
+  rtp_transport.c)
 
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
   target_compile_options(tests PRIVATE -Wall -Wextra -fsanitize=address)

--- a/tests/main.c
+++ b/tests/main.c
@@ -37,6 +37,7 @@ int main(int argc, char *argv[]) {
     SMOLRTSP_SUITE(io_vec);
     SMOLRTSP_SUITE(context);
     SMOLRTSP_SUITE(controller);
+    SMOLRTSP_SUITE(rtp_transport);
 
     GREATEST_MAIN_END();
 }

--- a/tests/rtp_transport.c
+++ b/tests/rtp_transport.c
@@ -1,0 +1,90 @@
+#include <smolrtsp/rtp_transport.h>
+#include <smolrtsp/transport.h>
+
+#include <greatest.h>
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#define PAYLOAD_HEADER "Hdr"
+#define PAYLOAD_BODY   "abcdefghij"
+
+TEST accessors_initial_state(void) {
+    int fds[2];
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_SEQPACKET, 0, fds));
+
+    srand(1);
+    SmolRTSP_Transport udp = smolrtsp_transport_udp(fds[0]);
+    SmolRTSP_RtpTransport *rtp =
+        SmolRTSP_RtpTransport_new(udp, /*payload_ty=*/96, /*clock_rate=*/90000);
+    ASSERT(rtp != NULL);
+
+    /* SSRC is randomly generated; we cannot assert a specific value, only
+     * that consecutive reads are stable. */
+    const uint32_t ssrc0 = SmolRTSP_RtpTransport_ssrc(rtp);
+    ASSERT_EQ_FMT(ssrc0, SmolRTSP_RtpTransport_ssrc(rtp), "%u");
+
+    /* Fresh transport: no packets, no octets. */
+    ASSERT_EQ_FMT((uint32_t)0, SmolRTSP_RtpTransport_pkt_count(rtp), "%u");
+    ASSERT_EQ_FMT((uint32_t)0, SmolRTSP_RtpTransport_octet_count(rtp), "%u");
+
+    VTABLE(SmolRTSP_RtpTransport, SmolRTSP_Droppable).drop(rtp);
+    close(fds[1]);
+    PASS();
+}
+
+TEST counters_advance_per_packet(void) {
+    int fds[2];
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_SEQPACKET, 0, fds));
+
+    srand(42);
+    SmolRTSP_Transport udp = smolrtsp_transport_udp(fds[0]);
+    SmolRTSP_RtpTransport *rtp =
+        SmolRTSP_RtpTransport_new(udp, /*payload_ty=*/96, /*clock_rate=*/90000);
+    ASSERT(rtp != NULL);
+
+    const uint32_t ssrc_before = SmolRTSP_RtpTransport_ssrc(rtp);
+
+    U8Slice99 hdr =
+        U8Slice99_new((uint8_t *)PAYLOAD_HEADER, sizeof(PAYLOAD_HEADER) - 1);
+    U8Slice99 body =
+        U8Slice99_new((uint8_t *)PAYLOAD_BODY, sizeof(PAYLOAD_BODY) - 1);
+    const size_t pl_octets = hdr.len + body.len;
+
+    const int r1 = SmolRTSP_RtpTransport_send_packet(
+        rtp, SmolRTSP_RtpTimestamp_Raw(1234),
+        /*marker=*/false, hdr, body);
+    ASSERT_EQ(0, r1);
+    ASSERT_EQ_FMT((uint32_t)1, SmolRTSP_RtpTransport_pkt_count(rtp), "%u");
+    ASSERT_EQ_FMT(
+        (uint32_t)pl_octets, SmolRTSP_RtpTransport_octet_count(rtp), "%u");
+
+    /* Drain the receive side so the next send doesn't block. */
+    char drain[256];
+    (void)read(fds[1], drain, sizeof(drain));
+
+    const int r2 = SmolRTSP_RtpTransport_send_packet(
+        rtp, SmolRTSP_RtpTimestamp_Raw(2345),
+        /*marker=*/true, hdr, body);
+    ASSERT_EQ(0, r2);
+    ASSERT_EQ_FMT((uint32_t)2, SmolRTSP_RtpTransport_pkt_count(rtp), "%u");
+    ASSERT_EQ_FMT(
+        (uint32_t)(pl_octets * 2), SmolRTSP_RtpTransport_octet_count(rtp),
+        "%u");
+
+    /* SSRC never changes for the lifetime of the transport. */
+    ASSERT_EQ_FMT(ssrc_before, SmolRTSP_RtpTransport_ssrc(rtp), "%u");
+
+    (void)read(fds[1], drain, sizeof(drain));
+
+    VTABLE(SmolRTSP_RtpTransport, SmolRTSP_Droppable).drop(rtp);
+    close(fds[1]);
+    PASS();
+}
+
+SUITE(rtp_transport) {
+    RUN_TEST(accessors_initial_state);
+    RUN_TEST(counters_advance_per_packet);
+}


### PR DESCRIPTION
Follow-up to #39. Adds three accessors so callers building RTCP Sender Reports (`smolrtsp/types/rtcp.h`) can populate the matching SSRC and the "sender's packet count" / "sender's octet count" fields per RFC 3550 §6.4.1:

\`\`\`c
uint32_t SmolRTSP_RtpTransport_ssrc(SmolRTSP_RtpTransport *self);
uint32_t SmolRTSP_RtpTransport_pkt_count(SmolRTSP_RtpTransport *self);
uint32_t SmolRTSP_RtpTransport_octet_count(SmolRTSP_RtpTransport *self);
\`\`\`

## Why

Before this PR the SSRC was sealed inside the struct (generated by `rand()` in `_new`), and no octet counter existed at all. SR emitters had to either generate a separate SSRC (which receivers cannot pair with the RTP stream) or fork smolrtsp. [Majestic's current SR emission](https://github.com/widgetii/majestic/pull/78) takes the workaround path — these accessors let it carry the matching SSRC and accurate counters end-to-end.

## What

- **`pkt_count`** advances by 1 per successful `_send_packet`.
- **`octet_count`** advances by `payload_header.len + payload.len`, which is the RFC's definition of "payload octets" (everything after the RTP header, including codec-specific payload-format bytes like NAL FU indicators).
- **`ssrc`** simply returns the value set by `_new`. Stable for the transport's lifetime.

## Tests

New `tests/rtp_transport.c` suite, two tests:

1. `accessors_initial_state` — fresh transport reports `pkt_count == 0`, `octet_count == 0`, SSRC stable on repeated reads.
2. `counters_advance_per_packet` — two `_send_packet` calls with a 3-byte payload header + 10-byte body. After call 1: `pkt_count == 1`, `octet_count == 13`. After call 2: `pkt_count == 2`, `octet_count == 26`. SSRC unchanged.

Total suite: 76 tests / 997 assertions pass (was 74/995).

## Out of scope (future)

- Accepting an SSRC in `_new` so callers can pin it externally (less invasive than the alternative of writing a setter, since the SSRC truly should not change mid-stream).
- Resetting counters explicitly — RFC 3550 says "The count is reset if the sender changes its SSRC identifier", which is implicitly handled since SSRC doesn't change.
- Receiver Reports / SDES / BYE.

The Majestic side will pick these up in a follow-up to unify the SR SSRC with the RTP SSRC and fill in the currently-zero counter fields.