### PR TITLE
RTCP RR/SDES/BYE serializers + explicit-SSRC RtpTransport constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
- - RTCP Sender Report (SR) serialization per [RFC 3550 §6.4.1](https://datatracker.ietf.org/doc/html/rfc3550#section-6.4.1). New header `smolrtsp/types/rtcp.h` exposing `SmolRTSP_RtcpSr`, `SmolRTSP_RtcpSr_size`, and `SmolRTSP_RtcpSr_serialize`. Currently emits the fixed 28-byte SR header (RC = 0); reception report blocks, SDES and BYE remain unimplemented (see #7).
+ - RTCP Sender Report (SR) serialization per [RFC 3550 §6.4.1](https://datatracker.ietf.org/doc/html/rfc3550#section-6.4.1). New header `smolrtsp/types/rtcp.h` exposing `SmolRTSP_RtcpSr`, `SmolRTSP_RtcpSr_size`, and `SmolRTSP_RtcpSr_serialize`. Currently emits the fixed 28-byte SR header (RC = 0).
+ - RTCP Receiver Report (RR), SDES with single CNAME item, and BYE serialization. New types `SmolRTSP_RtcpRr`, `SmolRTSP_RtcpSdesCname`, `SmolRTSP_RtcpBye` with matching `_size` / `_serialize` functions in `smolrtsp/types/rtcp.h`. SDES and BYE handle the variable-length item-list padding to 32-bit boundaries automatically.
  - `SmolRTSP_RtpTransport_ssrc`, `SmolRTSP_RtpTransport_pkt_count`, and `SmolRTSP_RtpTransport_octet_count` accessors so callers can populate the corresponding fields of an RTCP Sender Report. `pkt_count` and `octet_count` are now tracked inside `SmolRTSP_RtpTransport` and advance with each successful `_send_packet` call.
+ - `SmolRTSP_RtpTransport_new_with_ssrc` — a constructor that accepts an explicit SSRC instead of generating one via `rand()`. The plain `_new` is now a thin wrapper that supplies `rand()` as the SSRC.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ SmolRTSP is a simple [RTSP 1.0] server library tailored for embedded devices, su
    - [x] RTP over UDP
    - [x] SDP ([RFC 4566])
    - RTCP ([RFC 3550]):
-     - [x] Sender Report (SR) serialization
-     - [ ] Receiver Report (RR), SDES, BYE
+     - [x] Sender Report (SR), Receiver Report (RR), SDES (single CNAME), and BYE serialization
  - Supported RTP payload formats:
    - [x] H.264 ([RFC 6184])
    - [x] H.265 ([RFC 7798])

--- a/include/smolrtsp/rtp_transport.h
+++ b/include/smolrtsp/rtp_transport.h
@@ -59,6 +59,28 @@ SmolRTSP_RtpTransport *SmolRTSP_RtpTransport_new(
     uint32_t clock_rate) SMOLRTSP_PRIV_MUST_USE;
 
 /**
+ * Like #SmolRTSP_RtpTransport_new but uses an explicit SSRC instead of
+ * a randomly generated one.
+ *
+ * Useful when the caller needs the RTP stream's SSRC to match an
+ * externally-chosen identifier — e.g. an RTCP Sender Report constructed
+ * elsewhere, or a multi-stream pipeline that pins SSRCs by configuration.
+ *
+ * The plain #SmolRTSP_RtpTransport_new is equivalent to calling this
+ * with `(uint32_t)rand()` as the SSRC.
+ *
+ * @param[in] t The level-4 protocol (such as TCP or UDP).
+ * @param[in] payload_ty The RTP payload type.
+ * @param[in] clock_rate The RTP clock rate of @p payload_ty (Hz).
+ * @param[in] ssrc The SSRC identifier to use for every RTP packet.
+ *
+ * @pre `t.self && t.vptr`
+ */
+SmolRTSP_RtpTransport *SmolRTSP_RtpTransport_new_with_ssrc(
+    SmolRTSP_Transport t, uint8_t payload_ty, uint32_t clock_rate,
+    uint32_t ssrc) SMOLRTSP_PRIV_MUST_USE;
+
+/**
  * Sends an RTP packet.
  *
  * @param[out] self The RTP transport for sending this packet.

--- a/include/smolrtsp/types/rtcp.h
+++ b/include/smolrtsp/types/rtcp.h
@@ -19,6 +19,27 @@
 #define SMOLRTSP_RTCP_PT_SR 200
 
 /**
+ * RTCP packet type for Receiver Report (RFC 3550 §6.4.2).
+ */
+#define SMOLRTSP_RTCP_PT_RR 201
+
+/**
+ * RTCP packet type for Source Description (RFC 3550 §6.5).
+ */
+#define SMOLRTSP_RTCP_PT_SDES 202
+
+/**
+ * RTCP packet type for Goodbye (RFC 3550 §6.6).
+ */
+#define SMOLRTSP_RTCP_PT_BYE 203
+
+/**
+ * SDES item type for canonical end-point identifier (CNAME)
+ * (RFC 3550 §6.5.1).
+ */
+#define SMOLRTSP_RTCP_SDES_CNAME 1
+
+/**
  * The fixed wire size of an RTCP Sender Report with no reception report
  * blocks (RC = 0).
  *
@@ -131,3 +152,175 @@ size_t SmolRTSP_RtcpSr_size(SmolRTSP_RtcpSr self) SMOLRTSP_PRIV_MUST_USE;
  */
 uint8_t *SmolRTSP_RtcpSr_serialize(
     SmolRTSP_RtcpSr self, uint8_t buffer[restrict]) SMOLRTSP_PRIV_MUST_USE;
+
+/**
+ * The fixed wire size of an RTCP Receiver Report with no reception
+ * report blocks (RC = 0): a 4-byte common header plus the 4-byte SSRC
+ * of the packet sender = 8 bytes.
+ */
+#define SMOLRTSP_RTCP_RR_SIZE_BASE 8u
+
+/**
+ * An RTCP Receiver Report (RR) header (RFC 3550 §6.4.2).
+ *
+ *  0                   1                   2                   3
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |V=2|P|    RC   |   PT=RR=201   |             length            |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                     SSRC of packet sender                     |
+ * +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+ *
+ * Reception report blocks (RC > 0) are not yet supported; #rc must be
+ * zero.
+ */
+typedef struct {
+    /**
+     * (1 bit) Padding flag.
+     */
+    bool padding;
+
+    /**
+     * (5 bits) Reception report count. Must be `0` for this implementation.
+     */
+    uint8_t rc;
+
+    /**
+     * (32 bits) Synchronization source identifier of the packet sender.
+     * Network byte order; SSRC is opaque on the wire so either endianness
+     * works as long as it stays consistent with the matching RTP stream.
+     */
+    uint32_t ssrc;
+} SmolRTSP_RtcpRr;
+
+/**
+ * Computes the size of the binary @p self. Currently always returns
+ * #SMOLRTSP_RTCP_RR_SIZE_BASE.
+ */
+size_t SmolRTSP_RtcpRr_size(SmolRTSP_RtcpRr self) SMOLRTSP_PRIV_MUST_USE;
+
+/**
+ * Writes @p self to @p buffer.
+ *
+ * @param[in] self The RR packet to write.
+ * @param[out] buffer Must be at least `SmolRTSP_RtcpRr_size(self)` bytes.
+ *
+ * @return The pointer to the passed buffer.
+ *
+ * @pre `buffer != NULL`
+ * @pre `self.rc == 0`
+ */
+uint8_t *SmolRTSP_RtcpRr_serialize(
+    SmolRTSP_RtcpRr self, uint8_t buffer[restrict]) SMOLRTSP_PRIV_MUST_USE;
+
+/**
+ * An RTCP SDES packet with a single chunk containing a single CNAME
+ * item (RFC 3550 §6.5). This is the minimum useful SDES form and the
+ * one most senders emit alongside an SR/RR for receiver bookkeeping.
+ *
+ *  0                   1                   2                   3
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |V=2|P|   SC=1   |  PT=SDES=202 |             length            |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                          SSRC                                 |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * | CNAME=1 |  len  | user@host (UTF-8) ...                       |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * | 0  (item terminator) | zero padding to 32-bit boundary        |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ */
+typedef struct {
+    /**
+     * (1 bit) Padding flag.
+     */
+    bool padding;
+
+    /**
+     * (32 bits) SSRC of the source being described. Opaque; same caveat
+     * as #SmolRTSP_RtcpSr.ssrc.
+     */
+    uint32_t ssrc;
+
+    /**
+     * Canonical name (CNAME) in `user@host`-or-`host` form. Must not be
+     * NULL and must be ≤ 255 bytes (the SDES item length field is 8 bits).
+     */
+    const char *cname;
+} SmolRTSP_RtcpSdesCname;
+
+/**
+ * Computes the size of the binary @p self.
+ *
+ * Layout: 4-byte common header + 4-byte SSRC + 2-byte CNAME item header
+ * + N bytes of CNAME text + 1-byte item-list terminator, then zero-padded
+ * to a 32-bit boundary.
+ *
+ * @pre `self.cname != NULL`
+ * @pre `strlen(self.cname) <= 255`
+ */
+size_t
+SmolRTSP_RtcpSdesCname_size(SmolRTSP_RtcpSdesCname self) SMOLRTSP_PRIV_MUST_USE;
+
+/**
+ * Writes @p self to @p buffer.
+ *
+ * @pre `buffer != NULL`
+ * @pre `self.cname != NULL`
+ * @pre `strlen(self.cname) <= 255`
+ */
+uint8_t *SmolRTSP_RtcpSdesCname_serialize(
+    SmolRTSP_RtcpSdesCname self,
+    uint8_t buffer[restrict]) SMOLRTSP_PRIV_MUST_USE;
+
+/**
+ * An RTCP BYE packet for a single SSRC, optionally carrying a reason
+ * text (RFC 3550 §6.6).
+ *
+ *  0                   1                   2                   3
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |V=2|P|   SC=1   |  PT=BYE=203  |             length            |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                           SSRC                                |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * | (opt) len | reason text ...                                   |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ */
+typedef struct {
+    /**
+     * (1 bit) Padding flag.
+     */
+    bool padding;
+
+    /**
+     * (32 bits) SSRC of the source leaving the session.
+     */
+    uint32_t ssrc;
+
+    /**
+     * Optional human-readable reason text (NULL or empty string means
+     * no reason). Must be ≤ 255 bytes; the length field is 8 bits.
+     */
+    const char *reason;
+} SmolRTSP_RtcpBye;
+
+/**
+ * Computes the size of the binary @p self.
+ *
+ * Without a reason: 8 bytes (4 header + 4 SSRC). With a reason: the
+ * above plus 1 byte length + N bytes text, zero-padded to a 32-bit
+ * boundary.
+ *
+ * @pre `self.reason == NULL || strlen(self.reason) <= 255`
+ */
+size_t SmolRTSP_RtcpBye_size(SmolRTSP_RtcpBye self) SMOLRTSP_PRIV_MUST_USE;
+
+/**
+ * Writes @p self to @p buffer.
+ *
+ * @pre `buffer != NULL`
+ * @pre `self.reason == NULL || strlen(self.reason) <= 255`
+ */
+uint8_t *SmolRTSP_RtcpBye_serialize(
+    SmolRTSP_RtcpBye self, uint8_t buffer[restrict]) SMOLRTSP_PRIV_MUST_USE;

--- a/src/rtp_transport.c
+++ b/src/rtp_transport.c
@@ -23,13 +23,20 @@ compute_timestamp(SmolRTSP_RtpTimestamp ts, uint32_t clock_rate);
 
 SmolRTSP_RtpTransport *SmolRTSP_RtpTransport_new(
     SmolRTSP_Transport t, uint8_t payload_ty, uint32_t clock_rate) {
+    return SmolRTSP_RtpTransport_new_with_ssrc(
+        t, payload_ty, clock_rate, (uint32_t)rand());
+}
+
+SmolRTSP_RtpTransport *SmolRTSP_RtpTransport_new_with_ssrc(
+    SmolRTSP_Transport t, uint8_t payload_ty, uint32_t clock_rate,
+    uint32_t ssrc) {
     assert(t.self && t.vptr);
 
     SmolRTSP_RtpTransport *self = malloc(sizeof *self);
     assert(self);
 
     self->seq_num = 0;
-    self->ssrc = (uint32_t)rand();
+    self->ssrc = ssrc;
     self->pkt_count = 0;
     self->octet_count = 0;
     self->payload_ty = payload_ty;

--- a/src/types/rtcp.c
+++ b/src/types/rtcp.c
@@ -11,6 +11,25 @@
 #define RTCP_HEADER_PADDING_SHIFT 5
 #define RTCP_VERSION              2
 
+/* Pack the common 4-byte RTCP packet header into the first 4 bytes of
+ * `buffer`. `length_words` is the value of the wire length field (total
+ * packet size in 32-bit words minus one). */
+static uint8_t *write_rtcp_common_header(
+    uint8_t buffer[restrict], bool padding, uint8_t sc_or_rc, uint8_t pt,
+    uint16_t length_words) {
+    *buffer = ((uint8_t)RTCP_VERSION << RTCP_HEADER_VERSION_SHIFT) |
+              (sc_or_rc & 0x1f);
+    if (padding) {
+        *buffer |= ((uint8_t)1 << RTCP_HEADER_PADDING_SHIFT);
+    }
+    buffer++;
+    *buffer = pt;
+    buffer++;
+    const uint16_t length_be = htons(length_words);
+    buffer = SLICE99_APPEND(buffer, length_be);
+    return buffer;
+}
+
 size_t SmolRTSP_RtcpSr_size(SmolRTSP_RtcpSr self) {
     (void)self;
     return SMOLRTSP_RTCP_SR_SIZE_BASE;
@@ -23,31 +42,11 @@ SmolRTSP_RtcpSr_serialize(SmolRTSP_RtcpSr self, uint8_t buffer[restrict]) {
 
     uint8_t *buffer_backup = buffer;
 
-    /*
-     *  0                   1                   2                   3
-     *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-     * |V=2|P|    RC   |   PT=SR=200   |             length            |
-     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-     */
-
-    /* Pack V (2 bits), P (1 bit), RC (5 bits) into byte 0. */
-    *buffer =
-        ((uint8_t)RTCP_VERSION << RTCP_HEADER_VERSION_SHIFT) | (self.rc & 0x1f);
-    if (self.padding) {
-        *buffer |= ((uint8_t)1 << RTCP_HEADER_PADDING_SHIFT);
-    }
-    buffer++;
-
-    /* PT (8 bits). */
-    *buffer = (uint8_t)SMOLRTSP_RTCP_PT_SR;
-    buffer++;
-
-    /* Length: in 32-bit words minus one. For a base SR (28 B = 7 words),
-     * length = 6. Network byte order. */
-    const uint16_t length_be =
-        htons((uint16_t)((SMOLRTSP_RTCP_SR_SIZE_BASE / 4u) - 1u));
-    buffer = SLICE99_APPEND(buffer, length_be);
+    /* Length in 32-bit words minus one. For a base SR (28 B = 7 words),
+     * length = 6. */
+    buffer = write_rtcp_common_header(
+        buffer, self.padding, self.rc, (uint8_t)SMOLRTSP_RTCP_PT_SR,
+        (uint16_t)((SMOLRTSP_RTCP_SR_SIZE_BASE / 4u) - 1u));
 
     buffer = SLICE99_APPEND(buffer, self.ssrc);
     buffer = SLICE99_APPEND(buffer, self.ntp_sec);
@@ -57,4 +56,109 @@ SmolRTSP_RtcpSr_serialize(SmolRTSP_RtcpSr self, uint8_t buffer[restrict]) {
     buffer = SLICE99_APPEND(buffer, self.octet_count);
 
     return buffer_backup;
+}
+
+size_t SmolRTSP_RtcpRr_size(SmolRTSP_RtcpRr self) {
+    (void)self;
+    return SMOLRTSP_RTCP_RR_SIZE_BASE;
+}
+
+uint8_t *
+SmolRTSP_RtcpRr_serialize(SmolRTSP_RtcpRr self, uint8_t buffer[restrict]) {
+    assert(buffer);
+    assert(self.rc == 0 && "RTCP RR reception report blocks not yet supported");
+
+    uint8_t *buffer_backup = buffer;
+
+    /* Length in 32-bit words minus one. Base RR is 8 B = 2 words, so
+     * length = 1. */
+    buffer = write_rtcp_common_header(
+        buffer, self.padding, self.rc, (uint8_t)SMOLRTSP_RTCP_PT_RR,
+        (uint16_t)((SMOLRTSP_RTCP_RR_SIZE_BASE / 4u) - 1u));
+
+    buffer = SLICE99_APPEND(buffer, self.ssrc);
+    return buffer_backup;
+}
+
+/* SDES with one chunk + one CNAME item + 1-byte type-0 terminator,
+ * zero-padded so the total packet length is a multiple of 4. */
+size_t SmolRTSP_RtcpSdesCname_size(SmolRTSP_RtcpSdesCname self) {
+    assert(self.cname);
+    const size_t cname_len = strlen(self.cname);
+    assert(cname_len <= 255);
+    /* 4 header + 4 ssrc + 2 (CNAME type+len) + cname_len text + 1 terminator */
+    const size_t raw = 4 + 4 + 2 + cname_len + 1;
+    return (raw + 3u) & ~(size_t)3u;
+}
+
+uint8_t *SmolRTSP_RtcpSdesCname_serialize(
+    SmolRTSP_RtcpSdesCname self, uint8_t buffer[restrict]) {
+    assert(buffer);
+    assert(self.cname);
+
+    const size_t cname_len = strlen(self.cname);
+    assert(cname_len <= 255);
+    const size_t total = SmolRTSP_RtcpSdesCname_size(self);
+    uint8_t *const start = buffer;
+
+    /* SC = 1 (one chunk). length = total/4 - 1. */
+    buffer = write_rtcp_common_header(
+        buffer, self.padding, /*sc_or_rc=*/1u, (uint8_t)SMOLRTSP_RTCP_PT_SDES,
+        (uint16_t)((total / 4u) - 1u));
+
+    buffer = SLICE99_APPEND(buffer, self.ssrc);
+
+    /* CNAME item: type + length + text. */
+    *buffer++ = (uint8_t)SMOLRTSP_RTCP_SDES_CNAME;
+    *buffer++ = (uint8_t)cname_len;
+    memcpy(buffer, self.cname, cname_len);
+    buffer += cname_len;
+
+    /* Item-list terminator (type 0) then zero-pad to 32-bit boundary. */
+    *buffer++ = 0;
+    while ((size_t)(buffer - start) < total) {
+        *buffer++ = 0;
+    }
+
+    return start;
+}
+
+size_t SmolRTSP_RtcpBye_size(SmolRTSP_RtcpBye self) {
+    /* 4 header + 4 ssrc. Plus, if reason present:
+     *   1 byte length + N reason bytes, padded to 32-bit boundary. */
+    if (self.reason == NULL || self.reason[0] == '\0') {
+        return 8;
+    }
+    const size_t r_len = strlen(self.reason);
+    assert(r_len <= 255);
+    const size_t raw = 4 + 4 + 1 + r_len;
+    return (raw + 3u) & ~(size_t)3u;
+}
+
+uint8_t *
+SmolRTSP_RtcpBye_serialize(SmolRTSP_RtcpBye self, uint8_t buffer[restrict]) {
+    assert(buffer);
+
+    const size_t total = SmolRTSP_RtcpBye_size(self);
+    uint8_t *const start = buffer;
+
+    /* SC = 1 (one SSRC). */
+    buffer = write_rtcp_common_header(
+        buffer, self.padding, /*sc_or_rc=*/1u, (uint8_t)SMOLRTSP_RTCP_PT_BYE,
+        (uint16_t)((total / 4u) - 1u));
+
+    buffer = SLICE99_APPEND(buffer, self.ssrc);
+
+    if (self.reason != NULL && self.reason[0] != '\0') {
+        const size_t r_len = strlen(self.reason);
+        assert(r_len <= 255);
+        *buffer++ = (uint8_t)r_len;
+        memcpy(buffer, self.reason, r_len);
+        buffer += r_len;
+        while ((size_t)(buffer - start) < total) {
+            *buffer++ = 0;
+        }
+    }
+
+    return start;
 }

--- a/tests/rtp_transport.c
+++ b/tests/rtp_transport.c
@@ -84,7 +84,29 @@ TEST counters_advance_per_packet(void) {
     PASS();
 }
 
+TEST new_with_ssrc_uses_caller_value(void) {
+    int fds[2];
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_SEQPACKET, 0, fds));
+
+    SmolRTSP_Transport udp = smolrtsp_transport_udp(fds[0]);
+    SmolRTSP_RtpTransport *rtp = SmolRTSP_RtpTransport_new_with_ssrc(
+        udp, /*payload_ty=*/96, /*clock_rate=*/90000,
+        /*ssrc=*/0xdeadbeef);
+    ASSERT(rtp != NULL);
+
+    /* Caller-provided SSRC must be the one returned, not a rand() value. */
+    ASSERT_EQ_FMT(
+        (uint32_t)0xdeadbeef, SmolRTSP_RtpTransport_ssrc(rtp), "0x%08x");
+    ASSERT_EQ_FMT((uint32_t)0, SmolRTSP_RtpTransport_pkt_count(rtp), "%u");
+    ASSERT_EQ_FMT((uint32_t)0, SmolRTSP_RtpTransport_octet_count(rtp), "%u");
+
+    VTABLE(SmolRTSP_RtpTransport, SmolRTSP_Droppable).drop(rtp);
+    close(fds[1]);
+    PASS();
+}
+
 SUITE(rtp_transport) {
     RUN_TEST(accessors_initial_state);
     RUN_TEST(counters_advance_per_packet);
+    RUN_TEST(new_with_ssrc_uses_caller_value);
 }

--- a/tests/types/rtcp.c
+++ b/tests/types/rtcp.c
@@ -101,8 +101,189 @@ TEST sr_serialize_padding_flag(void) {
     PASS();
 }
 
+TEST rr_size_is_8_for_no_report_blocks(void) {
+    const SmolRTSP_RtcpRr rr = {0};
+    ASSERT_EQ((size_t)8, SmolRTSP_RtcpRr_size(rr));
+    ASSERT_EQ((size_t)SMOLRTSP_RTCP_RR_SIZE_BASE, SmolRTSP_RtcpRr_size(rr));
+    PASS();
+}
+
+TEST rr_serialize_wire_format(void) {
+    const SmolRTSP_RtcpRr rr = {
+        .padding = false,
+        .rc = 0,
+        .ssrc = htonl(0xcafebabe),
+    };
+
+    uint8_t buf[16] = {0};
+    const uint8_t *ret = SmolRTSP_RtcpRr_serialize(rr, buf);
+    ASSERT_EQ((const uint8_t *)buf, ret);
+
+    /* V=2 P=0 RC=0 PT=201 length=1 (= 8/4 - 1). */
+    ASSERT_EQ_FMT((uint8_t)0x80, buf[0], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)201, buf[1], "%u");
+    ASSERT_EQ_FMT((uint8_t)SMOLRTSP_RTCP_PT_RR, buf[1], "%u");
+    ASSERT_EQ_FMT((uint8_t)0x00, buf[2], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0x01, buf[3], "0x%02x");
+    /* SSRC bytes 4-7. */
+    ASSERT_EQ_FMT((uint8_t)0xca, buf[4], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0xfe, buf[5], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0xba, buf[6], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0xbe, buf[7], "0x%02x");
+    /* Bytes after the RR are untouched. */
+    for (size_t i = 8; i < sizeof(buf); i++) {
+        ASSERT_EQ_FMT((uint8_t)0, buf[i], "0x%02x");
+    }
+
+    PASS();
+}
+
+TEST sdes_cname_size_padding(void) {
+    /* CNAME "ab" → raw size = 4 + 4 + 2 + 2 + 1 = 13, pad to 16. */
+    SmolRTSP_RtcpSdesCname s = {.cname = "ab"};
+    ASSERT_EQ((size_t)16, SmolRTSP_RtcpSdesCname_size(s));
+
+    /* CNAME "abcdef" → raw = 4+4+2+6+1 = 17, pad to 20. */
+    s.cname = "abcdef";
+    ASSERT_EQ((size_t)20, SmolRTSP_RtcpSdesCname_size(s));
+
+    /* CNAME "" → raw = 4+4+2+0+1 = 11, pad to 12. */
+    s.cname = "";
+    ASSERT_EQ((size_t)12, SmolRTSP_RtcpSdesCname_size(s));
+
+    PASS();
+}
+
+TEST sdes_cname_serialize_wire_format(void) {
+    const SmolRTSP_RtcpSdesCname s = {
+        .padding = false,
+        .ssrc = htonl(0xdeadbeef),
+        .cname = "u@h",
+    };
+    /* Expected size: 4 + 4 + 2 + 3 + 1 = 14, padded to 16. */
+    const size_t expected_size = 16;
+    ASSERT_EQ(expected_size, SmolRTSP_RtcpSdesCname_size(s));
+
+    uint8_t buf[32] = {0};
+    const uint8_t *ret = SmolRTSP_RtcpSdesCname_serialize(s, buf);
+    ASSERT_EQ((const uint8_t *)buf, ret);
+
+    /* Common header: V=2 P=0 SC=1 → 0x81, PT=202, length = 16/4 - 1 = 3 */
+    ASSERT_EQ_FMT((uint8_t)0x81, buf[0], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)SMOLRTSP_RTCP_PT_SDES, buf[1], "%u");
+    ASSERT_EQ_FMT((uint8_t)0x00, buf[2], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0x03, buf[3], "0x%02x");
+
+    /* SSRC. */
+    ASSERT_EQ_FMT((uint8_t)0xde, buf[4], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0xad, buf[5], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0xbe, buf[6], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0xef, buf[7], "0x%02x");
+
+    /* CNAME item: type 1, length 3, then "u@h". */
+    ASSERT_EQ_FMT((uint8_t)SMOLRTSP_RTCP_SDES_CNAME, buf[8], "%u");
+    ASSERT_EQ_FMT((uint8_t)3, buf[9], "%u");
+    ASSERT_EQ_FMT((uint8_t)'u', buf[10], "%u");
+    ASSERT_EQ_FMT((uint8_t)'@', buf[11], "%u");
+    ASSERT_EQ_FMT((uint8_t)'h', buf[12], "%u");
+
+    /* Item terminator (type 0) + 0-padding to 16 B. */
+    ASSERT_EQ_FMT((uint8_t)0, buf[13], "%u");
+    ASSERT_EQ_FMT((uint8_t)0, buf[14], "%u");
+    ASSERT_EQ_FMT((uint8_t)0, buf[15], "%u");
+
+    /* Bytes after the SDES are untouched. */
+    for (size_t i = 16; i < sizeof(buf); i++) {
+        ASSERT_EQ_FMT((uint8_t)0, buf[i], "0x%02x");
+    }
+
+    PASS();
+}
+
+TEST bye_size_no_reason(void) {
+    const SmolRTSP_RtcpBye b = {.ssrc = htonl(0x1234), .reason = NULL};
+    ASSERT_EQ((size_t)8, SmolRTSP_RtcpBye_size(b));
+
+    const SmolRTSP_RtcpBye b_empty = {.ssrc = htonl(0x1234), .reason = ""};
+    ASSERT_EQ((size_t)8, SmolRTSP_RtcpBye_size(b_empty));
+    PASS();
+}
+
+TEST bye_size_with_reason(void) {
+    /* "bye!" (4 chars) → raw = 4 + 4 + 1 + 4 = 13, pad to 16. */
+    const SmolRTSP_RtcpBye b = {.reason = "bye!"};
+    ASSERT_EQ((size_t)16, SmolRTSP_RtcpBye_size(b));
+    PASS();
+}
+
+TEST bye_serialize_no_reason(void) {
+    const SmolRTSP_RtcpBye b = {
+        .padding = false,
+        .ssrc = htonl(0xfeedface),
+        .reason = NULL,
+    };
+    uint8_t buf[16] = {0};
+    const uint8_t *ret = SmolRTSP_RtcpBye_serialize(b, buf);
+    ASSERT_EQ((const uint8_t *)buf, ret);
+
+    /* V=2 P=0 SC=1 → 0x81, PT=203, length = 8/4 - 1 = 1. */
+    ASSERT_EQ_FMT((uint8_t)0x81, buf[0], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)SMOLRTSP_RTCP_PT_BYE, buf[1], "%u");
+    ASSERT_EQ_FMT((uint8_t)0x00, buf[2], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0x01, buf[3], "0x%02x");
+    /* SSRC */
+    ASSERT_EQ_FMT((uint8_t)0xfe, buf[4], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0xed, buf[5], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0xfa, buf[6], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)0xce, buf[7], "0x%02x");
+    /* Nothing after the SSRC. */
+    for (size_t i = 8; i < sizeof(buf); i++) {
+        ASSERT_EQ_FMT((uint8_t)0, buf[i], "0x%02x");
+    }
+
+    PASS();
+}
+
+TEST bye_serialize_with_reason(void) {
+    const SmolRTSP_RtcpBye b = {
+        .padding = false,
+        .ssrc = htonl(0x01020304),
+        .reason = "bye!",
+    };
+    /* Expected size 16: 4 header + 4 ssrc + 1 len + 4 reason + 3 pad. */
+    ASSERT_EQ((size_t)16, SmolRTSP_RtcpBye_size(b));
+
+    uint8_t buf[32] = {0};
+    SmolRTSP_RtcpBye_serialize(b, buf);
+
+    /* Header: SC=1, PT=203, length = 16/4 - 1 = 3. */
+    ASSERT_EQ_FMT((uint8_t)0x81, buf[0], "0x%02x");
+    ASSERT_EQ_FMT((uint8_t)SMOLRTSP_RTCP_PT_BYE, buf[1], "%u");
+    ASSERT_EQ_FMT((uint8_t)0x03, buf[3], "0x%02x");
+    /* Reason length = 4, then "bye!" text. */
+    ASSERT_EQ_FMT((uint8_t)4, buf[8], "%u");
+    ASSERT_EQ_FMT((uint8_t)'b', buf[9], "%u");
+    ASSERT_EQ_FMT((uint8_t)'y', buf[10], "%u");
+    ASSERT_EQ_FMT((uint8_t)'e', buf[11], "%u");
+    ASSERT_EQ_FMT((uint8_t)'!', buf[12], "%u");
+    /* Padding bytes 13-15 zero. */
+    ASSERT_EQ_FMT((uint8_t)0, buf[13], "%u");
+    ASSERT_EQ_FMT((uint8_t)0, buf[14], "%u");
+    ASSERT_EQ_FMT((uint8_t)0, buf[15], "%u");
+
+    PASS();
+}
+
 SUITE(types_rtcp) {
     RUN_TEST(sr_size_is_28_for_no_report_blocks);
     RUN_TEST(sr_serialize_wire_format);
     RUN_TEST(sr_serialize_padding_flag);
+    RUN_TEST(rr_size_is_8_for_no_report_blocks);
+    RUN_TEST(rr_serialize_wire_format);
+    RUN_TEST(sdes_cname_size_padding);
+    RUN_TEST(sdes_cname_serialize_wire_format);
+    RUN_TEST(bye_size_no_reason);
+    RUN_TEST(bye_size_with_reason);
+    RUN_TEST(bye_serialize_no_reason);
+    RUN_TEST(bye_serialize_with_reason);
 }


### PR DESCRIPTION
Completes the per-RFC-3550 RTCP coverage on the sender side. SR landed in #39; this adds RR/SDES/BYE so SR-emitting consumers can ship a compound packet (e.g. SR + SDES every 5s) and a clean BYE on session teardown. Also adds the explicit-SSRC constructor flagged as a follow-up in #40.

## New surface

\`\`\`c
#define SMOLRTSP_RTCP_PT_RR       201
#define SMOLRTSP_RTCP_PT_SDES     202
#define SMOLRTSP_RTCP_PT_BYE      203
#define SMOLRTSP_RTCP_SDES_CNAME    1

SmolRTSP_RtcpRr          / _size / _serialize  // §6.4.2, fixed 8 B (RC=0)
SmolRTSP_RtcpSdesCname   / _size / _serialize  // §6.5, single CNAME item
SmolRTSP_RtcpBye         / _size / _serialize  // §6.6, single SSRC, optional reason

SmolRTSP_RtpTransport *SmolRTSP_RtpTransport_new_with_ssrc(
    SmolRTSP_Transport t, uint8_t payload_ty, uint32_t clock_rate,
    uint32_t ssrc);
\`\`\`

The SDES and BYE serializers compute the variable wire size internally, including the 32-bit zero-padding the RFC requires. RR currently emits the fixed 8-byte header (RC = 0) under the same "RC blocks not yet supported" constraint as SR.

`SmolRTSP_RtpTransport_new` is now a thin wrapper that supplies `(uint32_t)rand()` to the new explicit-SSRC variant — fully backward compatible.

## Why

A SR-only sender is technically valid per §6.4.1 but many receivers expect at least a CNAME alongside (it's the field that identifies the source for QoS reports and statistics aggregation). The BYE provides a clean session-end signal so receivers don't have to wait for RTCP timeout to mark the source as departed.

The explicit-SSRC constructor is what consumers like [OpenIPC/majestic#79](https://github.com/widgetii/majestic/pull/79) currently work around by carrying the rand()-internal SSRC through the `_ssrc` accessor. With the new constructor, callers can pin the SSRC at session start and use the same value for both RTP and any SR/SDES/BYE they emit, even before the first packet is sent.

## Tests

`types_rtcp` suite (8 new tests):
- RR size and full byte-by-byte wire format
- SDES CNAME size semantics (padding to 32-bit boundary for 0/2/6-byte names)
- SDES CNAME wire format with a 3-byte CNAME (verifies item-type/length/text + terminator + padding)
- BYE size with and without reason
- BYE wire format with and without reason

`rtp_transport` suite (1 new test):
- `_new_with_ssrc` returns the caller-supplied value verbatim, counters still at zero

Total: 85 tests / 1091 assertions pass (was 76 / 997).

## Out of scope (future)

- Reception report blocks (RC > 0) on SR/RR. The serializers `assert(rc == 0)`.
- SDES items beyond CNAME (NAME, EMAIL, PHONE, LOC, TOOL, NOTE, PRIV). The current API accepts one CNAME per SDES packet; a more general builder can come if needed.
- Compound RTCP packets (multiple RTCP packets concatenated in one UDP datagram). RFC 3550 strongly recommends compound; consumers can already build these by concatenating individual serialized packets — but a helper would be nice.
- Receiver-side parsing.