### PR TITLE
rtp_transport: fix SSRC byte order + expose last_rtp_ts for SR

### DIFF
--- a/include/smolrtsp/rtp_transport.h
+++ b/include/smolrtsp/rtp_transport.h
@@ -146,3 +146,20 @@ uint32_t SmolRTSP_RtpTransport_pkt_count(SmolRTSP_RtpTransport *self)
  */
 uint32_t SmolRTSP_RtpTransport_octet_count(SmolRTSP_RtpTransport *self)
     SMOLRTSP_PRIV_MUST_USE;
+
+/**
+ * Returns the RTP timestamp (already in the wire/clock-rate domain) that
+ * was placed in the most recently transmitted RTP packet's header.
+ * Zero if no packet has been transmitted yet.
+ *
+ * Maps to the "RTP timestamp" field of an RTCP Sender Report
+ * (RFC 3550 §6.4.1) — the SR must carry an RTP timestamp in the same
+ * domain as the data packets so a receiver can correlate the SR's
+ * NTP/RTP pair against frames. Using a separately-computed `rtp_ts`
+ * (e.g. "ticks since SETUP") yields wall-clock estimates that drift
+ * by the gap between the two clock origins.
+ *
+ * @pre `self != NULL`
+ */
+uint32_t SmolRTSP_RtpTransport_last_rtp_ts(SmolRTSP_RtpTransport *self)
+    SMOLRTSP_PRIV_MUST_USE;

--- a/src/rtp_transport.c
+++ b/src/rtp_transport.c
@@ -71,7 +71,15 @@ int SmolRTSP_RtpTransport_send_packet(
         .payload_ty = self->payload_ty,
         .sequence_number = htons(self->seq_num),
         .timestamp = htobe32(compute_timestamp(ts, self->clock_rate)),
-        .ssrc = self->ssrc,
+        /* SSRC is the only multi-byte RTP-header field that was
+         * passed in host order — every other (sequence, timestamp,
+         * extension_*) is htobe32/htons'd in this same struct.
+         * Without this swap, on little-endian hosts the wire bytes
+         * are the byte-reversal of the SSRC, so receivers can't
+         * correlate the RTP stream with the htonl-ed SSRC in our
+         * RTCP packets (SR/RR/SDES/BYE). RFC 3550 §5.1 requires
+         * network byte order for all multi-byte RTP fields. */
+        .ssrc = htonl(self->ssrc),
         .csrc = NULL,
         .extension_profile = htons(0),
         .extension_payload_len = htons(0),

--- a/src/rtp_transport.c
+++ b/src/rtp_transport.c
@@ -13,6 +13,7 @@ struct SmolRTSP_RtpTransport {
     uint32_t ssrc;
     uint32_t pkt_count;
     uint32_t octet_count;
+    uint32_t last_rtp_ts;
     uint8_t payload_ty;
     uint32_t clock_rate;
     SmolRTSP_Transport transport;
@@ -39,6 +40,7 @@ SmolRTSP_RtpTransport *SmolRTSP_RtpTransport_new_with_ssrc(
     self->ssrc = ssrc;
     self->pkt_count = 0;
     self->octet_count = 0;
+    self->last_rtp_ts = 0;
     self->payload_ty = payload_ty;
     self->clock_rate = clock_rate;
     self->transport = t;
@@ -62,6 +64,8 @@ int SmolRTSP_RtpTransport_send_packet(
     U8Slice99 payload_header, U8Slice99 payload) {
     assert(self);
 
+    const uint32_t rtp_ts = compute_timestamp(ts, self->clock_rate);
+
     const SmolRTSP_RtpHeader header = {
         .version = 2,
         .padding = false,
@@ -70,7 +74,7 @@ int SmolRTSP_RtpTransport_send_packet(
         .marker = marker,
         .payload_ty = self->payload_ty,
         .sequence_number = htons(self->seq_num),
-        .timestamp = htobe32(compute_timestamp(ts, self->clock_rate)),
+        .timestamp = htobe32(rtp_ts),
         /* SSRC is the only multi-byte RTP-header field that was
          * passed in host order — every other (sequence, timestamp,
          * extension_*) is htobe32/htons'd in this same struct.
@@ -106,6 +110,7 @@ int SmolRTSP_RtpTransport_send_packet(
          * or padding). The codec-specific `payload_header` is part of the
          * payload from the receiver's point of view. */
         self->octet_count += (uint32_t)(payload_header.len + payload.len);
+        self->last_rtp_ts = rtp_ts;
     }
 
     return ret;
@@ -146,4 +151,9 @@ uint32_t SmolRTSP_RtpTransport_pkt_count(SmolRTSP_RtpTransport *self) {
 uint32_t SmolRTSP_RtpTransport_octet_count(SmolRTSP_RtpTransport *self) {
     assert(self);
     return self->octet_count;
+}
+
+uint32_t SmolRTSP_RtpTransport_last_rtp_ts(SmolRTSP_RtpTransport *self) {
+    assert(self);
+    return self->last_rtp_ts;
 }


### PR DESCRIPTION
## Summary

Two small, related fixes in `SmolRTSP_RtpTransport` that became visible
once #39/#40/#41 turned this library into something that emits both RTP
and RTCP for the same stream. With #41 merged, callers (Majestic /
others) build RTCP SR/RR/SDES/BYE packets whose SSRC field they pass
through `htonl(...)`, and receivers correlate the RTP stream with the
SR via SSRC. That correlation was silently broken in two ways:

### 1. `rtp_transport: write SSRC in network byte order` (849b386)

The RTP header builder in `send_packet` was writing `.ssrc = self->ssrc`
directly — the raw uint32_t bytes in host order. Every other multi-byte
field in the same struct (sequence_number, timestamp, extension_*) goes
through htons/htobe32. SSRC was the oversight. On little-endian hosts
(x86, ARM) this puts the byte-reversed SSRC on the wire, contrary to
RFC 3550 §5.1.

Latent for years because the test suite only checks the getter
round-trips the value, not the wire-byte order. The bug surfaces the
moment a sender starts emitting RTCP: the SR carries the SSRC in
network order, the RTP packets carry it in host order, receivers see
"two different SSRCs" and never correlate them.

Empirical proof on Hi3516EV300 / Majestic build pre-fix: tcpdump shows
RTP wire bytes `c9 dd f7 45` and the matching RTCP SR bytes
`45 f7 dd c9` — byte-reversed pair. Post-fix: identical bytes both
ways. gst-rtspsrc immediately starts populating
`GstReferenceTimestampMeta` from the SR.

### 2. `rtp_transport: expose last_rtp_ts for SR construction` (f0c8630)

Adds `SmolRTSP_RtpTransport_last_rtp_ts()` returning the RTP timestamp
field of the most recently transmitted packet (zero before any send).

This is the missing piece for RFC 3550 §6.4.1-compliant Sender Reports:
"The middle 32 bits out of 64 in the NTP timestamp ... corresponds to
the same time as the RTP timestamp." A correct SR carries (NTP_now,
RTP_ts_in_same_clock_as_RTP_packets). Without this accessor, callers
that build SR externally have no way to read the actual clock domain
the RTP packets used — they end up synthesising `rtp_ts` from
e.g. "elapsed since SETUP", which lives in a different epoch than the
encoder-PTS-driven RTP packet timestamps. Receivers then apply
`NTP_sr + (rtp_ts_frame - rtp_ts_sr) * GST_SECOND / clock_rate` with a
wrong base, producing arbitrarily-offset stamps (saw 86 min on an
EV300 that had been up ~80 min when SETUP arrived).

The Majestic side of this is in the companion PR.

## Test plan

- [x] `make test` passes (existing getter round-trip tests still hold)
- [x] Live verification end-to-end on Hi3516EV300 + IMX335 with Majestic
      built against this branch — pure-Python correlator
      (`tools/manual_rtcp_correlator.py` in widgetii/openipc_camera)
      reports ±50 ms drift, down from +5160 s pre-fix
- [x] gst-rtspsrc with `add-reference-timestamp-meta=true` now populates
      `GstReferenceTimestampMeta` per frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)