### PR TITLE
nal_transport: fix S=E=1 FU header on MTU-boundary NALs (closes #14)

### DIFF
--- a/src/nal_transport.c
+++ b/src/nal_transport.c
@@ -73,7 +73,7 @@ int SmolRTSP_NalTransport_send_packet(
                  nalu_size =
                      SmolRTSP_NalHeader_size(nalu.header) + nalu.payload.len;
 
-    if (nalu_size < max_packet_size) {
+    if (nalu_size <= max_packet_size) {
         /* RFC 6184 §5.1 / RFC 7798 §4.4.1: M set only on the very last
          * RTP packet of the access unit. Non-VCL NALs (SPS/PPS/SEI/VPS)
          * never end an AU even if the caller passes is_au_end=true on
@@ -99,8 +99,17 @@ int SmolRTSP_NalTransport_send_packet(
 static int send_fragmentized_nal_data(
     SmolRTSP_RtpTransport *t, SmolRTSP_RtpTimestamp ts, bool is_au_end,
     size_t max_packet_size, SmolRTSP_NalUnit nalu) {
-    const size_t rem = nalu.payload.len % max_packet_size,
-                 packets_count = (nalu.payload.len - rem) / max_packet_size;
+    /* Each FU packet is fu_header_size + chunk bytes; carve the payload
+     * into chunks that leave room for the FU header so the resulting RTP
+     * packets stay within max_packet_size. Combined with the `<=` threshold
+     * in send_packet, this also guarantees the fragmented path always
+     * emits at least two FUs, so an FU header never has both S=1 and E=1
+     * (forbidden by RFC 6184 §5.8 / RFC 7798 §4.4.3). */
+    const size_t fu_header_size = SmolRTSP_NalHeader_fu_size(nalu.header);
+    assert(max_packet_size > fu_header_size);
+    const size_t chunk_size = max_packet_size - fu_header_size,
+                 rem = nalu.payload.len % chunk_size,
+                 packets_count = (nalu.payload.len - rem) / chunk_size;
 
     for (size_t packet_idx = 0; packet_idx < packets_count; packet_idx++) {
         const bool is_first_fragment = 0 == packet_idx,
@@ -108,9 +117,9 @@ static int send_fragmentized_nal_data(
                        0 == rem && (packets_count - 1 == packet_idx);
 
         const U8Slice99 fu_data = U8Slice99_sub(
-            nalu.payload, packet_idx * max_packet_size,
+            nalu.payload, packet_idx * chunk_size,
             is_last_fragment ? nalu.payload.len
-                             : (packet_idx + 1) * max_packet_size);
+                             : (packet_idx + 1) * chunk_size);
         const SmolRTSP_NalUnit fu = {nalu.header, fu_data};
 
         if (send_fu(
@@ -122,7 +131,7 @@ static int send_fragmentized_nal_data(
 
     if (rem != 0) {
         const U8Slice99 fu_data =
-            U8Slice99_advance(nalu.payload, packets_count * max_packet_size);
+            U8Slice99_advance(nalu.payload, packets_count * chunk_size);
         const SmolRTSP_NalUnit fu = {nalu.header, fu_data};
         const bool is_first_fragment = 0 == packets_count,
                    is_last_fragment = true;


### PR DESCRIPTION
## Summary

Closes #14 (\"S and E combination error\") and a related MTU-overshoot bug, both in \`src/nal_transport.c\`.

### Bug 1 — S=1 AND E=1 on the same FU header

When a NAL's payload length fell in \`[max_packet_size - nal_header_size, max_packet_size]\`, the threshold \`nalu_size < max_packet_size\` pushed it into the fragmented path. The fragmentation arithmetic (using \`max_packet_size\` as the chunk size, not \`max_packet_size - fu_header_size\`) then produced exactly one FU with \`is_first_fragment = is_last_fragment = true\`, emitting a single FU-A/FU-B header with both **S=1 and E=1** — explicitly forbidden by RFC 6184 §5.8 / RFC 7798 §4.4.3.

The trigger window is narrow (2 payload-length values for H.264, 3 for H.265) but slice-mode encoders target it by design (slice size ≈ MTU), so it surfaces in production whenever the caller calibrates slice size to MTU.

### Bug 2 — every FU packet overshoots MTU

Independent of #14: the chunk size in the fragmented path was \`max_packet_size\` directly, so each FU packet was \`fu_header_size + max_packet_size\` bytes — overshooting the configured limit by 2 bytes (H.264) or 3 bytes (H.265). Tolerated in practice because callers typically configure conservatively (1200 in a 1500-byte MTU world), but still incorrect.

### Fix

Two lines:

\`\`\`c
// Threshold uses <= so the equality case stays unfragmented:
if (nalu_size <= max_packet_size) { /* whole-NAL */ }

// Chunk size leaves room for the FU header:
const size_t chunk_size = max_packet_size - SmolRTSP_NalHeader_fu_size(nalu.header);
\`\`\`

Since \`fu_header_size > nal_header_size\` for both codecs (H.264 2>1, H.265 3>2), any payload that takes the fragmented path is guaranteed to span at least two chunks — no FU header can carry both S=1 and E=1.

## Test plan

- [x] All 85 existing tests still pass (\`tests/\` suite).
- [x] **Wire-level verification on HiSi hi3516cv500** with \`sliceBytes=1200\` (MTU-targeted slice mode), captured via tcpdump + tshark over UDP RTP transport, 4-second window:
  - 968 FU-A fragments split perfectly as **484 S=1/E=0 + 484 S=0/E=1**, zero S=E=1 combos
  - Max RTP payload = exactly 1200 bytes (configured limit); previously was 1202
  - All 12 AUs still have exactly 1 marker bit (PR #43 unaffected)
- [x] Frame-mode (single NAL per AU) preserved: unfragmented threshold widened by 1 byte (the equality case), behaviour otherwise identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)