### PR TITLE
util: add smolrtsp_parse_interleaved_frame for back-channel ingress

### DIFF
--- a/include/smolrtsp/util.h
+++ b/include/smolrtsp/util.h
@@ -163,3 +163,63 @@ uint32_t smolrtsp_interleaved_header(uint8_t channel_id, uint16_t payload_len)
 void smolrtsp_parse_interleaved_header(
     const uint8_t data[restrict static 4], uint8_t *restrict channel_id,
     uint16_t *restrict payload_len);
+
+/**
+ * The result of #smolrtsp_parse_interleaved_frame.
+ */
+typedef enum {
+    /**
+     * A complete interleaved frame was parsed.
+     *
+     * `channel_id`, `payload`, and `consumed` outputs are set.
+     */
+    SmolRTSP_InterleavedFrameStatus_Complete,
+
+    /**
+     * The input starts with the `$` magic byte but the full frame has not
+     * yet arrived.
+     *
+     * Outputs are untouched. The caller should preserve the buffer and wait
+     * for more bytes before retrying.
+     */
+    SmolRTSP_InterleavedFrameStatus_Partial,
+
+    /**
+     * The input does not begin with `$` and is therefore not an interleaved
+     * binary frame.
+     *
+     * Outputs are untouched. The caller should fall through to whichever
+     * other parser handles the protocol (typically
+     * #SmolRTSP_Request_parse or #SmolRTSP_Response_parse).
+     */
+    SmolRTSP_InterleavedFrameStatus_NotInterleaved,
+} SmolRTSP_InterleavedFrameStatus;
+
+/**
+ * Parses one interleaved binary frame
+ * ([RFC 2326
+ * §10.12](https://datatracker.ietf.org/doc/html/rfc2326#section-10.12)).
+ *
+ * Used by RTSP servers that want to receive client-pushed media (RTSP back
+ * channel / ONVIF Profile T) on a TCP-interleaved RTSP connection. Frames
+ * look like `$<channel:u8><length:u16-be><payload>` on the wire.
+ *
+ * @param[in] input The raw bytes at the head of the receive buffer.
+ * @param[out] channel_id The one-byte channel identifier of the frame, set
+ *             only on #SmolRTSP_InterleavedFrameStatus_Complete.
+ * @param[out] payload A slice into @p input covering just the frame payload
+ *             (no `$`/channel/length prefix), set only on Complete. The
+ *             slice is valid as long as @p input remains valid.
+ * @param[out] consumed The number of bytes (4-byte header + payload) the
+ *             caller should drain from the buffer, set only on Complete.
+ *
+ * @return Frame status (see enum).
+ *
+ * @pre `channel_id != NULL`
+ * @pre `payload != NULL`
+ * @pre `consumed != NULL`
+ */
+SmolRTSP_InterleavedFrameStatus smolrtsp_parse_interleaved_frame(
+    CharSlice99 input, uint8_t *restrict channel_id,
+    U8Slice99 *restrict payload,
+    size_t *restrict consumed) SMOLRTSP_PRIV_MUST_USE;

--- a/src/util.c
+++ b/src/util.c
@@ -159,3 +159,37 @@ void smolrtsp_parse_interleaved_header(
     memcpy(payload_len, data + 2, sizeof *payload_len);
     *payload_len = ntohs(*payload_len);
 }
+
+SmolRTSP_InterleavedFrameStatus smolrtsp_parse_interleaved_frame(
+    CharSlice99 input, uint8_t *restrict channel_id,
+    U8Slice99 *restrict payload, size_t *restrict consumed) {
+    assert(channel_id);
+    assert(payload);
+    assert(consumed);
+
+    if (input.len == 0) {
+        return SmolRTSP_InterleavedFrameStatus_Partial;
+    }
+    if ('$' != input.ptr[0]) {
+        return SmolRTSP_InterleavedFrameStatus_NotInterleaved;
+    }
+    if (input.len < sizeof(uint32_t)) {
+        return SmolRTSP_InterleavedFrameStatus_Partial;
+    }
+
+    uint8_t ch = 0;
+    uint16_t payload_len = 0;
+    smolrtsp_parse_interleaved_header(
+        (const uint8_t *)input.ptr, &ch, &payload_len);
+
+    const size_t total = sizeof(uint32_t) + (size_t)payload_len;
+    if (input.len < total) {
+        return SmolRTSP_InterleavedFrameStatus_Partial;
+    }
+
+    *channel_id = ch;
+    *payload = U8Slice99_new(
+        (uint8_t *)input.ptr + sizeof(uint32_t), (size_t)payload_len);
+    *consumed = total;
+    return SmolRTSP_InterleavedFrameStatus_Complete;
+}

--- a/tests/util.c
+++ b/tests/util.c
@@ -129,10 +129,117 @@ TEST parse_interleaved_header(void) {
     PASS();
 }
 
+TEST parse_interleaved_frame_complete(void) {
+    /* $, channel=7, len=3 (big-endian 0x0003), payload "abc", trailing "x" */
+    const uint8_t data[] = {'$', 7, 0x00, 0x03, 'a', 'b', 'c', 'x'};
+    CharSlice99 input = CharSlice99_new((char *)(uintptr_t)data, sizeof data);
+
+    uint8_t channel_id = 0;
+    U8Slice99 payload = U8Slice99_empty();
+    size_t consumed = 0;
+
+    const SmolRTSP_InterleavedFrameStatus status =
+        smolrtsp_parse_interleaved_frame(
+            input, &channel_id, &payload, &consumed);
+
+    ASSERT_EQ(SmolRTSP_InterleavedFrameStatus_Complete, status);
+    ASSERT_EQ_FMT(7, channel_id, "%" PRIu8);
+    ASSERT_EQ_FMT((size_t)3, payload.len, "%zu");
+    ASSERT_EQ('a', (char)payload.ptr[0]);
+    ASSERT_EQ('b', (char)payload.ptr[1]);
+    ASSERT_EQ('c', (char)payload.ptr[2]);
+    ASSERT_EQ_FMT((size_t)7, consumed, "%zu"); /* 4-byte header + 3 payload */
+
+    PASS();
+}
+
+TEST parse_interleaved_frame_partial_header(void) {
+    /* Only the $ byte arrived so far. */
+    const uint8_t data[] = {'$'};
+    CharSlice99 input = CharSlice99_new((char *)(uintptr_t)data, sizeof data);
+
+    uint8_t channel_id = 99;
+    U8Slice99 payload = U8Slice99_empty();
+    size_t consumed = 999;
+
+    const SmolRTSP_InterleavedFrameStatus status =
+        smolrtsp_parse_interleaved_frame(
+            input, &channel_id, &payload, &consumed);
+
+    ASSERT_EQ(SmolRTSP_InterleavedFrameStatus_Partial, status);
+    /* Outputs untouched on Partial. */
+    ASSERT_EQ_FMT(99, channel_id, "%" PRIu8);
+    ASSERT_EQ_FMT((size_t)999, consumed, "%zu");
+
+    PASS();
+}
+
+TEST parse_interleaved_frame_partial_payload(void) {
+    /* Header says len=10 but only 2 payload bytes have arrived. */
+    const uint8_t data[] = {'$', 3, 0x00, 0x0a, 'x', 'y'};
+    CharSlice99 input = CharSlice99_new((char *)(uintptr_t)data, sizeof data);
+
+    uint8_t channel_id = 0;
+    U8Slice99 payload = U8Slice99_empty();
+    size_t consumed = 0;
+
+    const SmolRTSP_InterleavedFrameStatus status =
+        smolrtsp_parse_interleaved_frame(
+            input, &channel_id, &payload, &consumed);
+
+    ASSERT_EQ(SmolRTSP_InterleavedFrameStatus_Partial, status);
+
+    PASS();
+}
+
+TEST parse_interleaved_frame_not_interleaved(void) {
+    /* Buffer starts with an RTSP request, not a $-frame. */
+    const char request[] = "OPTIONS rtsp://x RTSP/1.0\r\n";
+    CharSlice99 input = CharSlice99_from_str((char *)request);
+
+    uint8_t channel_id = 0;
+    U8Slice99 payload = U8Slice99_empty();
+    size_t consumed = 0;
+
+    const SmolRTSP_InterleavedFrameStatus status =
+        smolrtsp_parse_interleaved_frame(
+            input, &channel_id, &payload, &consumed);
+
+    ASSERT_EQ(SmolRTSP_InterleavedFrameStatus_NotInterleaved, status);
+
+    PASS();
+}
+
+TEST parse_interleaved_frame_zero_length(void) {
+    /* Valid frame with zero-byte payload. */
+    const uint8_t data[] = {'$', 5, 0x00, 0x00};
+    CharSlice99 input = CharSlice99_new((char *)(uintptr_t)data, sizeof data);
+
+    uint8_t channel_id = 0;
+    U8Slice99 payload = U8Slice99_new((uint8_t *)"sentinel", 8);
+    size_t consumed = 0;
+
+    const SmolRTSP_InterleavedFrameStatus status =
+        smolrtsp_parse_interleaved_frame(
+            input, &channel_id, &payload, &consumed);
+
+    ASSERT_EQ(SmolRTSP_InterleavedFrameStatus_Complete, status);
+    ASSERT_EQ_FMT(5, channel_id, "%" PRIu8);
+    ASSERT_EQ_FMT((size_t)0, payload.len, "%zu");
+    ASSERT_EQ_FMT((size_t)4, consumed, "%zu");
+
+    PASS();
+}
+
 SUITE(util) {
     RUN_TEST(parse_transport_config);
     RUN_TEST(parse_transport_minimal);
     RUN_TEST(parse_transport_trailing_semicolon);
     RUN_TEST(interleaved_header);
     RUN_TEST(parse_interleaved_header);
+    RUN_TEST(parse_interleaved_frame_complete);
+    RUN_TEST(parse_interleaved_frame_partial_header);
+    RUN_TEST(parse_interleaved_frame_partial_payload);
+    RUN_TEST(parse_interleaved_frame_not_interleaved);
+    RUN_TEST(parse_interleaved_frame_zero_length);
 }


### PR DESCRIPTION
## Summary

Adds a small public helper that decodes one `$<channel><len><payload>` interleaved binary frame from a buffer slice, with three-way status: `Complete` / `Partial` / `NotInterleaved`. This is the building block an RTSP server needs to actually *consume* inbound RTP frames on a TCP-interleaved RTSP connection — for example to support the RTSP back channel / [ONVIF Profile T 2-way audio](https://github.com/OpenIPC/smolrtsp/issues/5).

\`smolrtsp_parse_interleaved_header()\` already decodes the 4-byte prefix; this PR adds the slice-shaped variant that also delivers the payload and signals partial vs not-interleaved.

The library is otherwise untouched — \`SmolRTSP_Request_parse\` still silently skips any interleaved frames at the head of a request, so existing servers (no back-channel) keep working unchanged.

## Test plan

- [x] 5 new unit tests in \`tests/util.c\` covering Complete, partial header, partial payload, NotInterleaved, and zero-length payload. All 126 tests pass.
- [x] Used downstream from smolrtsp-libevent (PR follows) on a real RTSP server (Majestic) to dispatch inbound G.711 RTP frames; end-to-end verified on a hi3516cv500 camera.

🤖 Generated with [Claude Code](https://claude.com/claude-code)