### PR TITLE
udp: close fd on transport drop

### DIFF
--- a/include/smolrtsp/transport.h
+++ b/include/smolrtsp/transport.h
@@ -63,6 +63,11 @@ SmolRTSP_Transport smolrtsp_transport_tcp(
  * necessarily UDP. E.g., you may use a `SOCK_SEQPACKET` socket for local
  * communication.
  *
+ * Takes ownership of @p fd: the descriptor is `close(2)`d when the
+ * returned transport is dropped. Callers must not `close` it themselves
+ * and must not hand the same @p fd to two transports — `dup(2)` first if
+ * multiple transports need to share an underlying socket.
+ *
  * @param[in] fd The socket file descriptor to be provided with data.
  *
  * @pre `fd >= 0`
@@ -71,6 +76,9 @@ SmolRTSP_Transport smolrtsp_transport_udp(int fd) SMOLRTSP_PRIV_MUST_USE;
 
 /**
  * Creates a new UDP transport with address.
+ *
+ * Takes ownership of @p fd; see #smolrtsp_transport_udp for the
+ * descriptor-lifetime contract.
  *
  * @param[in] fd The socket file descriptor to be provided with data.
  * @param[in] addr Pointer to address data (e.g., sockaddr_un or sockaddr_in).

--- a/src/transport/udp.c
+++ b/src/transport/udp.c
@@ -4,6 +4,7 @@
 #include <errno.h>
 #include <stddef.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include <arpa/inet.h>
 #include <netinet/in.h>
@@ -53,6 +54,10 @@ static void SmolRTSP_UdpTransport_drop(VSelf) {
     VSELF(SmolRTSP_UdpTransport);
     assert(self);
 
+    if (self->fd >= 0) {
+        (void)close(self->fd);
+        self->fd = -1;
+    }
     free(self);
 }
 


### PR DESCRIPTION
## Summary

- `SmolRTSP_UdpTransport_drop()` freed the wrapper struct but never closed `self->fd`, leaking the underlying socket on every drop.
- In RTSP server use this surfaced as one `ESTABLISHED` UDP socket per RTP stream surviving the client disconnect — reported in OpenIPC/majestic#262.
- Reproduced on a Hi3516EV300 camera: single `ffplay -rtsp_transport udp` session left a `127.0.0.1:<port> ↔ <client_port> ESTABLISHED` UDP entry persisting in `netstat` indefinitely; matches the reporter's symptom and grows monotonically across sessions.

## Fix

`_drop()` now `close(2)`s `self->fd` (guarded so it's safe against double-drop) and sets the fd field back to `-1`. Header comments on both `smolrtsp_transport_udp` and `smolrtsp_transport_udp_address` are updated to spell out the ownership contract — the transport closes the fd on drop, callers must not close it themselves, and callers that want to share an underlying socket between two transports must `dup(2)` first.

## Breaking change for embedders

Any existing caller that closes the fd itself after dropping the transport (or hands the same fd to two transports) will double-close after this lands. Known downstream call sites in majestic are handled in lockstep with the vendored-smolrtsp bump (separate PR).

## Test plan

- [x] Existing 126-test suite passes (`transport` and `rtp_transport` suites cover the drop path through socketpair fds)
- [x] Reproduced leak on Hi3516EV300 with stock binary, confirmed fix on same camera with patched binary (single UDP session: 0 leftover `ESTABLISHED` UDP entries; 5× churn: count stays bounded; audio+video: 0 leftover for both)
- [x] TCP-interleaved transport (separate vtable) unaffected — verified no `SmolRTSP_UdpTransport` constructed on the TCP path

🤖 Generated with [Claude Code](https://claude.com/claude-code)