### PR TITLE
tcp: coalesce interleaved frame into one Writer write

### DIFF
--- a/src/transport/tcp.c
+++ b/src/transport/tcp.c
@@ -1,9 +1,11 @@
 #include <smolrtsp/transport.h>
 
+#include <alloca.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <arpa/inet.h>
 
@@ -51,26 +53,36 @@ static int SmolRTSP_TcpTransport_transmit(VSelf, SmolRTSP_IoVecSlice bufs) {
     const uint32_t header =
         smolrtsp_interleaved_header(self->channel_id, htons(total_bytes));
 
-    VCALL(self->w, lock);
-    ssize_t ret =
-        VCALL(self->w, write, CharSlice99_new((char *)&header, sizeof header));
-    if (ret != sizeof header) {
-        VCALL(self->w, unlock);
-        return -1;
-    }
-
+    /* Build the full interleaved RTSP frame (4-byte header + payload
+     * iovec) in a single contiguous buffer, then issue exactly ONE
+     * write to the underlying Writer. Splitting the frame into
+     * header + per-iovec writes interacts badly with downstream
+     * Writers backed by libevent's bufferevent — the multi-step
+     * sequence of evbuffer_add calls can desync the chain's
+     * last_with_datap / free-space bookkeeping under certain
+     * fragment-size patterns, producing a heap-buffer-overflow at
+     * exactly one chunk boundary past the end of the current
+     * evbuffer chain. Coalescing into one write keeps every
+     * interleaved frame inside a single evbuffer_add and side-steps
+     * the multi-step interaction entirely. It also matches the UDP
+     * transport's behaviour (one sendmsg per RTP packet) and tightens
+     * the critical section around the Writer lock. */
+    const size_t frame_len = sizeof header + total_bytes;
+    uint8_t *frame = alloca(frame_len);
+    memcpy(frame, &header, sizeof header);
+    size_t off = sizeof header;
     for (size_t i = 0; i < bufs.len; i++) {
-        const CharSlice99 vec =
-            CharSlice99_new(bufs.ptr[i].iov_base, bufs.ptr[i].iov_len);
-        ret = VCALL(self->w, write, vec);
-        if (ret != (ssize_t)vec.len) {
-            VCALL(self->w, unlock);
-            return -1;
-        }
+        memcpy(frame + off, bufs.ptr[i].iov_base, bufs.ptr[i].iov_len);
+        off += bufs.ptr[i].iov_len;
     }
+    assert(off == frame_len);
+
+    VCALL(self->w, lock);
+    const ssize_t ret =
+        VCALL(self->w, write, CharSlice99_new((char *)frame, frame_len));
     VCALL(self->w, unlock);
 
-    return 0;
+    return ret == (ssize_t)frame_len ? 0 : -1;
 }
 
 static bool SmolRTSP_TcpTransport_is_full(VSelf) {


### PR DESCRIPTION
## Summary

`SmolRTSP_TcpTransport_transmit` (`src/transport/tcp.c`) emits the 4-byte interleaved header and each payload iovec entry as separate calls into the underlying `SmolRTSP_Writer` — typically four `Writer::write` invocations per FU-A H.264 fragment (interleaved header, RTP header, FU header, payload).

When the Writer is a libevent bufferevent (the common downstream use case), each call funnels into `evbuffer_add`, which walks the chain to append into the last `evbuffer_chain`. Under certain fragment-size patterns the multi-step sequence of small `evbuffer_add` calls desyncs the chain's free-space bookkeeping (the `last_with_datap` cursor advances past where the next write expects to land), producing a heap-buffer-overflow exactly one chunk boundary past the end of the current evbuffer chain.

The crash is rare and load-pattern dependent — it does not reproduce on any single packet size, only under sustained variable-size load (FU-A fragments of mixed sizes hitting evbuffer chunk boundaries).

## Fix

Build the full interleaved frame (header + concatenated iovec contents) in a single contiguous `alloca`'d buffer, then issue exactly **one** `Writer::write` call.

This:

- Keeps every frame inside a single `evbuffer_add` and side-steps the multi-step chain interaction entirely.
- Matches the UDP transport's behaviour (one `sendmsg` per RTP packet).
- Tightens the critical section around the Writer lock.
- Restores correct succeed-or-fail-atomically semantics on the bufferevent (the old per-iovec loop could leave the buffer in a half-written state if a middle `write` failed).

Frame size is bounded by the consumer's configured max packet size (typical MTU 1500 B, capped at ~4 KB for high-fragment configs), so the `alloca` is well within stack limits on every supported platform — including the armv7 SoCs that surfaced this report.

## Validation

ASan-instrumented build on armv7, libevent 2.2.1-alpha-dev (`665d79f`), gcc 13.3 cross.

- **Before the fix**: stress workload (concurrent video-RTSP + secondary data-track + RTSP-session churn + periodic control-plane SOAP requests) reproducibly hits the heap-buffer-overflow within ~3-4 minutes. ASan stack:
  ```
  WRITE of size 442 at +4096 past a 4096-byte chunk
    #0 memcpy
    #1 evbuffer_add (libevent_core)
    #2 SmolRTSP_TcpTransport_transmit  src/transport/tcp.c:65
    #3 SmolRTSP_RtpTransport_send_packet  src/rtp_transport.c:105
    #4 send_fu  src/nal_transport.c:190
    ...
  ```
- **After the fix**: same workload runs **15 minutes uninterrupted** with zero ASan reports. RTSP video stream decode (3840×2160 H.264 @ 20 fps) confirmed working via `ffmpeg -frames:v 30 -f null`.

## Notes

- `src/transport/udp.c` is unaffected — it already uses a single `sendmsg` with the iovec, which is what the TCP path now mirrors at the Writer level.
- No public API change.
- A defensive `assert(off == frame_len)` after the copy loop catches future iovec-length-vs-total mismatches at debug-build time.