### PR TITLE
Fix unbounded `alloca` stack-overflow DoS in RTSP parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  - Fix the `SmolRTSP_NalTransportConfig_default` value for H.265 ([PR #17](https://github.com/OpenIPC/smolrtsp/pull/17)).
 
+### Security
+
+ - Fix a remotely-triggerable stack-overflow denial of service in RTSP parsing (reported by [LL-V](https://github.com/LL-V), [#58](https://github.com/OpenIPC/smolrtsp/issues/58)). Attacker-controlled header values and numeric fields were copied onto the stack via unbounded `alloca` (`CharSlice99_alloca_c_str`), so a multi-megabyte `CSeq`/`Content-Length` could crash the process. Integer fields (`CSeq`, `Content-Length`, RTSP version, status code) are now parsed with a bounded, overflow-checked parser that also rejects a negative `Content-Length` (previously wrapped to `SIZE_MAX`), and header values longer than the new `SMOLRTSP_MAX_HEADER_VALUE` (default 1024, override-able) are rejected with the new `SmolRTSP_ParseError_HeaderValueTooLong` parse error.
+
 ## 0.1.3 - 2023-03-12
 
 ### Fixed

--- a/examples/server.c
+++ b/examples/server.c
@@ -433,9 +433,9 @@ Client_before(VSelf, SmolRTSP_Context *ctx, const SmolRTSP_Request *req) {
     (void)ctx;
 
     printf(
-        "%s %s CSeq=%" PRIu32 ".\n",
-        CharSlice99_alloca_c_str(req->start_line.method),
-        CharSlice99_alloca_c_str(req->start_line.uri), req->cseq);
+        "%.*s %.*s CSeq=%" PRIu32 ".\n", (int)req->start_line.method.len,
+        req->start_line.method.ptr, (int)req->start_line.uri.len,
+        req->start_line.uri.ptr, req->cseq);
 
     return SmolRTSP_ControlFlow_Continue;
 }

--- a/include/smolrtsp/types/error.h
+++ b/include/smolrtsp/types/error.h
@@ -58,6 +58,9 @@ SmolRTSP_ParseType_str(SmolRTSP_ParseType self) SMOLRTSP_PRIV_MUST_USE;
  *  - `HeaderMapOverflow` -- An attempt to add a header to a full header map.
  *  - `MissingCSeq` -- Missing the `CSeq` header.
  *  - `InvalidCSeq` -- Failed to parse the `CSeq` header.
+ *  - `HeaderValueTooLong` -- A header value exceeds #SMOLRTSP_MAX_HEADER_VALUE.
+ * Arguments:
+ *    1. The offending value.
  *
  * See [Datatype99](https://github.com/hirrolot/datatype99) for the macro usage.
  */
@@ -70,7 +73,8 @@ datatype99(
     (SmolRTSP_ParseError_TypeMismatch, SmolRTSP_ParseType, CharSlice99),
     (SmolRTSP_ParseError_HeaderMapOverflow),
     (SmolRTSP_ParseError_MissingCSeq),
-    (SmolRTSP_ParseError_InvalidCSeq, CharSlice99)
+    (SmolRTSP_ParseError_InvalidCSeq, CharSlice99),
+    (SmolRTSP_ParseError_HeaderValueTooLong, CharSlice99)
 );
 // clang-format on
 

--- a/include/smolrtsp/types/header.h
+++ b/include/smolrtsp/types/header.h
@@ -65,6 +65,20 @@ bool SmolRTSP_Header_eq(
     const SmolRTSP_Header *restrict rhs) SMOLRTSP_PRIV_MUST_USE;
 
 /**
+ * The maximum length, in bytes, of a single RTSP header value accepted by
+ * #SmolRTSP_Header_parse.
+ *
+ * Values longer than this are rejected with
+ * #SmolRTSP_ParseError_HeaderValueTooLong. This bounds the memory that header
+ * parsing may touch and guards against denial-of-service from unbounded header
+ * values sent by an untrusted peer. Define this macro before including this
+ * header to override the default.
+ */
+#ifndef SMOLRTSP_MAX_HEADER_VALUE
+#define SMOLRTSP_MAX_HEADER_VALUE 1024
+#endif
+
+/**
  * `Accept`.
  */
 #define SMOLRTSP_HEADER_ACCEPT (CharSlice99_from_str("Accept"))

--- a/src/types/error.c
+++ b/src/types/error.c
@@ -67,6 +67,14 @@ int SmolRTSP_ParseError_print(SmolRTSP_ParseError self, SmolRTSP_Writer w) {
                        CharSlice99_from_str("`"),
                    });
         }
+        of(SmolRTSP_ParseError_HeaderValueTooLong, value) {
+            return SMOLRTSP_WRITE_SLICES(
+                w, {
+                       CharSlice99_from_str("Header value too long `"),
+                       TRUNCATE_STR(*value),
+                       CharSlice99_from_str("`"),
+                   });
+        }
     }
 
     return -1;

--- a/src/types/header.c
+++ b/src/types/header.c
@@ -42,6 +42,11 @@ SmolRTSP_Header_parse(SmolRTSP_Header *restrict self, CharSlice99 input) {
     header.value =
         CharSlice99_from_ptrdiff(header.value.ptr, input.ptr - strlen("\r\n"));
 
+    if (header.value.len > SMOLRTSP_MAX_HEADER_VALUE) {
+        return SmolRTSP_ParseResult_Failure(
+            SmolRTSP_ParseError_HeaderValueTooLong(header.value));
+    }
+
     *self = header;
 
     return SmolRTSP_ParseResult_complete(input.ptr - backup.ptr);

--- a/src/types/parsing.c
+++ b/src/types/parsing.c
@@ -2,6 +2,7 @@
 
 #include <assert.h>
 #include <ctype.h>
+#include <stdint.h>
 #include <string.h>
 
 SmolRTSP_ParseResult smolrtsp_match_until(
@@ -150,4 +151,25 @@ SmolRTSP_ParseResult smolrtsp_match_header_name(CharSlice99 input) {
     }
 
     return smolrtsp_match_until(input, header_name_char_matcher, NULL);
+}
+
+bool smolrtsp_parse_uint(CharSlice99 input, uintmax_t max, uintmax_t *result) {
+    assert(result);
+
+    if (input.len == 0 || !isdigit((unsigned char)input.ptr[0])) {
+        return false;
+    }
+
+    uintmax_t acc = 0;
+    for (size_t i = 0; i < input.len && isdigit((unsigned char)input.ptr[i]);
+         i++) {
+        const unsigned digit = (unsigned)(input.ptr[i] - '0');
+        if (acc > max / 10 || (acc == max / 10 && digit > max % 10)) {
+            return false;
+        }
+        acc = acc * 10 + digit;
+    }
+
+    *result = acc;
+    return true;
 }

--- a/src/types/parsing.h
+++ b/src/types/parsing.h
@@ -46,3 +46,22 @@ SmolRTSP_ParseResult smolrtsp_match_non_whitespaces(CharSlice99 input);
 SmolRTSP_ParseResult smolrtsp_match_numeric(CharSlice99 input);
 SmolRTSP_ParseResult smolrtsp_match_ident(CharSlice99 input);
 SmolRTSP_ParseResult smolrtsp_match_header_name(CharSlice99 input);
+
+/**
+ * Parses a non-negative decimal integer from the beginning of @p input.
+ *
+ * At least one leading ASCII digit is required; scanning stops at the first
+ * non-digit (any trailing characters are ignored, matching `sscanf` leniency).
+ * The accumulated value must not exceed @p max. No sign is accepted.
+ *
+ * This is a bounded, allocation-free replacement for
+ * `sscanf(CharSlice99_alloca_c_str(...), ...)` on untrusted input: it never
+ * allocates and rejects overflow instead of wrapping.
+ *
+ * @param[out] result The parsed value; written only when the return value is
+ * `true`.
+ *
+ * @return `true` if at least one digit was parsed without exceeding @p max,
+ * `false` otherwise (no leading digit or overflow).
+ */
+bool smolrtsp_parse_uint(CharSlice99 input, uintmax_t max, uintmax_t *result);

--- a/src/types/request.c
+++ b/src/types/request.c
@@ -92,12 +92,13 @@ SmolRTSP_Request_parse(SmolRTSP_Request *restrict self, CharSlice99 input) {
         &self->header_map, SMOLRTSP_HEADER_CONTENT_LENGTH, &content_length);
 
     if (content_length_found) {
-        if (sscanf(
-                CharSlice99_alloca_c_str(content_length), "%zd",
-                &content_length_int) != 1) {
+        uintmax_t content_length_num;
+        if (!smolrtsp_parse_uint(
+                content_length, SIZE_MAX, &content_length_num)) {
             return SmolRTSP_ParseResult_Failure(
                 SmolRTSP_ParseError_ContentLength(content_length));
         }
+        content_length_int = (size_t)content_length_num;
     }
 
     MATCH(SmolRTSP_MessageBody_parse(&self->body, input, content_length_int));
@@ -109,13 +110,13 @@ SmolRTSP_Request_parse(SmolRTSP_Request *restrict self, CharSlice99 input) {
         return SmolRTSP_ParseResult_Failure(SmolRTSP_ParseError_MissingCSeq());
     }
 
-    uint32_t cseq;
-    if (sscanf(CharSlice99_alloca_c_str(cseq_value), "%" SCNu32, &cseq) != 1) {
+    uintmax_t cseq;
+    if (!smolrtsp_parse_uint(cseq_value, UINT32_MAX, &cseq)) {
         return SmolRTSP_ParseResult_Failure(
             SmolRTSP_ParseError_InvalidCSeq(cseq_value));
     }
 
-    self->cseq = cseq;
+    self->cseq = (uint32_t)cseq;
 
     return SmolRTSP_ParseResult_complete(input.ptr - backup.ptr);
 }

--- a/src/types/response.c
+++ b/src/types/response.c
@@ -93,12 +93,13 @@ SmolRTSP_Response_parse(SmolRTSP_Response *restrict self, CharSlice99 input) {
         &self->header_map, SMOLRTSP_HEADER_CONTENT_LENGTH, &content_length);
 
     if (content_length_is_found) {
-        if (sscanf(
-                CharSlice99_alloca_c_str(content_length), "%zd",
-                &content_length_int) != 1) {
+        uintmax_t content_length_num;
+        if (!smolrtsp_parse_uint(
+                content_length, SIZE_MAX, &content_length_num)) {
             return SmolRTSP_ParseResult_Failure(
                 SmolRTSP_ParseError_ContentLength(content_length));
         }
+        content_length_int = (size_t)content_length_num;
     }
 
     MATCH(SmolRTSP_MessageBody_parse(&self->body, input, content_length_int));
@@ -110,13 +111,13 @@ SmolRTSP_Response_parse(SmolRTSP_Response *restrict self, CharSlice99 input) {
         return SmolRTSP_ParseResult_Failure(SmolRTSP_ParseError_MissingCSeq());
     }
 
-    uint32_t cseq;
-    if (sscanf(CharSlice99_alloca_c_str(cseq_value), "%" SCNu32, &cseq) != 1) {
+    uintmax_t cseq;
+    if (!smolrtsp_parse_uint(cseq_value, UINT32_MAX, &cseq)) {
         return SmolRTSP_ParseResult_Failure(
             SmolRTSP_ParseError_InvalidCSeq(cseq_value));
     }
 
-    self->cseq = cseq;
+    self->cseq = (uint32_t)cseq;
 
     return SmolRTSP_ParseResult_complete(input.ptr - backup.ptr);
 }

--- a/src/types/rtsp_version.c
+++ b/src/types/rtsp_version.c
@@ -4,10 +4,8 @@
 
 #include <assert.h>
 #include <inttypes.h>
-#include <stdio.h>
+#include <stdint.h>
 #include <string.h>
-
-#include <alloca.h>
 
 ssize_t SmolRTSP_RtspVersion_serialize(
     const SmolRTSP_RtspVersion *restrict self, SmolRTSP_Writer w) {
@@ -36,20 +34,20 @@ SmolRTSP_ParseResult SmolRTSP_RtspVersion_parse(
     MATCH(smolrtsp_match_numeric(input));
     minor = CharSlice99_from_ptrdiff(minor.ptr, input.ptr);
 
-    uint8_t major_int, minor_int;
+    uintmax_t major_int, minor_int;
 
-    if (sscanf(CharSlice99_alloca_c_str(major), "%" SCNu8, &major_int) != 1) {
+    if (!smolrtsp_parse_uint(major, UINT8_MAX, &major_int)) {
         return SmolRTSP_ParseResult_Failure(
             SmolRTSP_ParseError_TypeMismatch(SmolRTSP_ParseType_Int, major));
     }
 
-    if (sscanf(CharSlice99_alloca_c_str(minor), "%" SCNu8, &minor_int) != 1) {
+    if (!smolrtsp_parse_uint(minor, UINT8_MAX, &minor_int)) {
         return SmolRTSP_ParseResult_Failure(
             SmolRTSP_ParseError_TypeMismatch(SmolRTSP_ParseType_Int, minor));
     }
 
-    self->major = major_int;
-    self->minor = minor_int;
+    self->major = (uint8_t)major_int;
+    self->minor = (uint8_t)minor_int;
 
     return SmolRTSP_ParseResult_complete(input.ptr - backup.ptr);
 }

--- a/src/types/status_code.c
+++ b/src/types/status_code.c
@@ -4,10 +4,8 @@
 
 #include <assert.h>
 #include <inttypes.h>
-#include <stdio.h>
+#include <stdint.h>
 #include <string.h>
-
-#include <alloca.h>
 
 ssize_t SmolRTSP_StatusCode_serialize(
     const SmolRTSP_StatusCode *restrict self, SmolRTSP_Writer w) {
@@ -28,13 +26,13 @@ SmolRTSP_ParseResult SmolRTSP_StatusCode_parse(
     MATCH(smolrtsp_match_numeric(input));
     code = CharSlice99_from_ptrdiff(code.ptr, input.ptr);
 
-    SmolRTSP_StatusCode code_int;
-    if (sscanf(CharSlice99_alloca_c_str(code), "%" SCNu16, &code_int) != 1) {
+    uintmax_t code_int;
+    if (!smolrtsp_parse_uint(code, UINT16_MAX, &code_int)) {
         return SmolRTSP_ParseResult_Failure(
             SmolRTSP_ParseError_TypeMismatch(SmolRTSP_ParseType_Int, code));
     }
 
-    *self = code_int;
+    *self = (SmolRTSP_StatusCode)code_int;
 
     return SmolRTSP_ParseResult_complete(input.ptr - backup.ptr);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,7 +44,8 @@ add_executable(
   controller.c
   context.c
   transport.c
-  rtp_transport.c)
+  rtp_transport.c
+  security.c)
 
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
   target_compile_options(tests PRIVATE -Wall -Wextra -fsanitize=address)

--- a/tests/main.c
+++ b/tests/main.c
@@ -39,5 +39,7 @@ int main(int argc, char *argv[]) {
     SMOLRTSP_SUITE(controller);
     SMOLRTSP_SUITE(rtp_transport);
 
+    SMOLRTSP_SUITE(security);
+
     GREATEST_MAIN_END();
 }

--- a/tests/security.c
+++ b/tests/security.c
@@ -1,0 +1,115 @@
+// Regression tests for issue #58: unbounded `alloca` on attacker-controlled
+// RTSP field values caused a stack-overflow DoS. Parsing hostile input must now
+// return a clean `Failure` (never crash or hang). AddressSanitizer is always on
+// for the test binary, so a reintroduced overflow would also be caught here.
+
+#include <smolrtsp/types/request.h>
+#include <smolrtsp/types/response.h>
+
+#include <greatest.h>
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <slice99.h>
+
+// Builds "OPTIONS * RTSP/1.0\r\n<name>: <value_len '9's>\r\nCSeq: 1\r\n\r\n"
+// into a freshly malloc'd buffer of length `*out_total`. Caller frees.
+static char *
+make_request(const char *name, size_t value_len, size_t *out_total) {
+    static const char line0[] = "OPTIONS * RTSP/1.0\r\n";
+    static const char tail[] = "CSeq: 1\r\n\r\n";
+    const size_t name_len = strlen(name);
+    const size_t total = (sizeof line0 - 1) + name_len + 2 /* ": " */ +
+                         value_len + 2 /* "\r\n" */ + (sizeof tail - 1);
+
+    char *buf = malloc(total + 1);
+    if (buf == NULL) {
+        return NULL;
+    }
+
+    char *p = buf;
+    memcpy(p, line0, sizeof line0 - 1), p += sizeof line0 - 1;
+    memcpy(p, name, name_len), p += name_len;
+    *p++ = ':', *p++ = ' ';
+    memset(p, '9', value_len), p += value_len;
+    *p++ = '\r', *p++ = '\n';
+    memcpy(p, tail, sizeof tail - 1), p += sizeof tail - 1;
+    *p = '\0';
+
+    *out_total = total;
+    return buf;
+}
+
+static bool request_fails(const char *s) {
+    SmolRTSP_Request req = SmolRTSP_Request_uninit();
+    return SmolRTSP_ParseResult_is_failure(
+        SmolRTSP_Request_parse(&req, CharSlice99_from_str((char *)s)));
+}
+
+// A multi-megabyte header value must be rejected, not `alloca`'d onto the
+// stack. Covers the mandatory `CSeq`/`Content-Length` path plus an arbitrary
+// header.
+TEST huge_header_value_does_not_crash(void) {
+    static const size_t HUGE = 2 * 1024 * 1024; // 2 MiB
+    const char *const names[] = {"CSeq", "Content-Length", "X-Padding"};
+
+    for (size_t i = 0; i < sizeof names / sizeof *names; i++) {
+        size_t total = 0;
+        char *buf = make_request(names[i], HUGE, &total);
+        ASSERT(buf != NULL);
+
+        SmolRTSP_Request req = SmolRTSP_Request_uninit();
+        const SmolRTSP_ParseResult ret =
+            SmolRTSP_Request_parse(&req, CharSlice99_new(buf, total));
+        ASSERT(SmolRTSP_ParseResult_is_failure(ret));
+
+        free(buf);
+    }
+
+    PASS();
+}
+
+// Integer fields within the length cap must still be range-checked instead of
+// silently overflowing (previously via `sscanf`).
+TEST integer_fields_are_bounded(void) {
+    // `CSeq` overflows uint32_t.
+    ASSERT(request_fails("OPTIONS * RTSP/1.0\r\nCSeq: 4294967296\r\n\r\n"));
+    // Negative `Content-Length` must be rejected, not wrapped to SIZE_MAX
+    // (which previously left the parser waiting for that many body bytes).
+    ASSERT(request_fails(
+        "OPTIONS * RTSP/1.0\r\nCSeq: 1\r\nContent-Length: -1\r\n\r\n"));
+    // RTSP version major overflows uint8_t.
+    ASSERT(request_fails("OPTIONS * RTSP/999.0\r\nCSeq: 1\r\n\r\n"));
+
+    PASS();
+}
+
+// The response status code must likewise be bounded (uint16_t).
+TEST status_code_is_bounded(void) {
+    SmolRTSP_Response resp = SmolRTSP_Response_uninit();
+    const SmolRTSP_ParseResult ret = SmolRTSP_Response_parse(
+        &resp, CharSlice99_from_str("RTSP/1.0 99999 OK\r\nCSeq: 1\r\n\r\n"));
+    ASSERT(SmolRTSP_ParseResult_is_failure(ret));
+
+    PASS();
+}
+
+// Well-formed input is unaffected by the new bounds.
+TEST valid_request_still_parses(void) {
+    SmolRTSP_Request req = SmolRTSP_Request_uninit();
+    const SmolRTSP_ParseResult ret = SmolRTSP_Request_parse(
+        &req, CharSlice99_from_str("OPTIONS * RTSP/1.0\r\nCSeq: 42\r\n\r\n"));
+    ASSERT(SmolRTSP_ParseResult_is_complete(ret));
+    ASSERT_EQ_FMT((uint32_t)42, req.cseq, "%u");
+
+    PASS();
+}
+
+SUITE(security) {
+    RUN_TEST(huge_header_value_does_not_crash);
+    RUN_TEST(integer_fields_are_bounded);
+    RUN_TEST(status_code_is_bounded);
+    RUN_TEST(valid_request_still_parses);
+}


### PR DESCRIPTION
## Summary

`SmolRTSP_Request_parse` / `SmolRTSP_Response_parse` and their helpers turned untrusted RTSP header values and numeric fields into C strings with `CharSlice99_alloca_c_str(x)` — i.e. `alloca(x.len + 1)` — with **no upper bound**. A remote peer can send a multi-megabyte `CSeq`/`Content-Length` (or an oversized RTSP version / status code) and overflow the stack, crashing the process. No authentication is required, and the threshold is far below the 8 MB PoC on the small per-thread stacks typical of OpenIPC targets.

Reported by @LL-V in #58.

Fixes #58.

## Fix

Two independent layers, so hostile input now returns a clean `Failure` instead of crashing or hanging:

1. **Bounded, `alloca`-free integer parsing.** A new `smolrtsp_parse_uint()` parses `CSeq` (u32), `Content-Length` (`size_t`), RTSP version (u8) and status code (u16) directly from the slice with an overflow check, replacing every `alloca`+`sscanf` site. This also fixes a secondary bug: `Content-Length: -1` was scanned with `%zd` into a `size_t`, wrapping to `SIZE_MAX` and leaving the parser waiting forever for body bytes — negative / oversized lengths are now rejected.

2. **Header-value length cap.** `SmolRTSP_Header_parse` rejects any value longer than the new `SMOLRTSP_MAX_HEADER_VALUE` (default **1024**, override via `#define`) with the new `SmolRTSP_ParseError_HeaderValueTooLong`. Every header value passes through this single choke point, so the remaining (now bounded) `alloca` sites — `smolrtsp_scanf_header` and `smolrtsp_parse_transport` — can only ever see ≤ 1 KiB slices.

The benign `alloca`s (serialize-path `alloca_fmt` on the library's own integers; fixed-size RTP/NAL headers) are unchanged. The example server no longer `alloca`s the request method / URI for logging.

## New public API

- `SMOLRTSP_MAX_HEADER_VALUE` — compile-time cap, override-able.
- `SmolRTSP_ParseError_HeaderValueTooLong` — new parse-error variant.

## Test plan

New `security` suite (AddressSanitizer is always on for tests) asserting a `Failure` (never a crash) for:

- multi-megabyte `CSeq` / `Content-Length` / arbitrary header values,
- in-cap numeric overflow (`CSeq: 4294967296`), negative `Content-Length`, `RTSP/999.0`, status `99999`,
- plus a positive control that a normal request still parses.

Verified locally:

- `bash scripts/build.sh` — clean.
- `bash scripts/test.sh` — **80/80 under ASan**, new suite 4/4.
- `clang-format --dry-run --Werror` — clean.
- Example (`server` + smolrtsp-libevent) builds clean with `-Wall -Wextra -fsanitize=address`.

## Out of scope

Unbounded buffering *before* a CRLF (memory exhaustion, distinct from this stack overflow) is the I/O-agnostic integration layer's responsibility — integrators driving the streaming parser should cap total buffered request size (e.g. a read high-watermark in the libevent integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
