### PR TITLE
examples: bump smolrtsp-libevent pin to include the 400-on-parse-failure fix

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,7 +12,7 @@ include(FetchContent)
 FetchContent_Declare(
     smolrtsp-libevent
     GIT_REPOSITORY https://github.com/OpenIPC/smolrtsp-libevent.git
-    GIT_TAG 369b1a38688122521552dee6023fcbdb9cf6aa6b
+    GIT_TAG b0329b4f8e72ff03f2b674ffdbfdc8553523ddf2
 )
 
 FetchContent_MakeAvailable(smolrtsp-libevent)


### PR DESCRIPTION
## Summary

Bumps the `smolrtsp-libevent` pin in `examples/CMakeLists.txt` from `369b1a3` to `b0329b4` (current `main`), pulling in:

- the interleaved-frame dispatch refactor (OpenIPC/smolrtsp-libevent#2), and
- the `400 Bad Request` reply on parse failure (OpenIPC/smolrtsp-libevent#3).

The old pin predates the interleaved-frame API (`smolrtsp_parse_interleaved_frame` / `SmolRTSP_InterleavedFrameStatus`, in `smolrtsp/util.h`) that the current integration relies on, so the example no longer built against it.

## Verification

Built the example against this branch (smolrtsp master) + the bumped libevent and exercised it live:

| Request | Response |
|---|---|
| valid `OPTIONS` | `RTSP/1.0 200 OK` |
| bad `CSeq` (non-numeric) | `RTSP/1.0 400 Bad Request` |
| missing `CSeq` | `RTSP/1.0 400 Bad Request` |
| oversized header (1100 B > cap) | `RTSP/1.0 400 Bad Request` |
| garbage request line | `RTSP/1.0 400 Bad Request` |

Previously the malformed/oversized cases were silently dropped (the client hung until timeout). ASan clean throughout.

## Context

Completes the chain started by #59 (bounded RTSP parsing / `alloca` DoS fix): the parser reliably returns a parse `Failure` on bad input, and the integration now surfaces that as a proper `400`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
